### PR TITLE
Pipeline object

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,25 +1,15 @@
 import datetime as dt
+from src.hydrophone import Hydrophone
+from src.pipeline import NoiseAnalysisPipeline
 
-import matplotlib.pyplot as plt
+# Create Pipeline
+pipeline = NoiseAnalysisPipeline(Hydrophone.ORCASOUND_LAB, pqt_folder='pqt', delta_f=1000, delta_t=1)
 
-# Local imports
-from orca_hls_utils.DateRangeHLSStream import DateRangeHLSStream
-from src import pipeline
+# Generate Parquet File
+pipeline.generate_parquet_file(dt.date(2022, 11, 5), dt.date(2022, 11, 6))
 
+# Generate Week of data
+pipeline.generate_parquet_file_batch(dt.date(2022, 10, 1), 7, dt.timedelta(days=1))
 
-
-
-# Create spectrograms and visualize one
-grams = pipeline.ts_to_spectrogram(
-    dt.date(2022, 11, 5),
-    dt.date(2022, 11, 6),
-    'wav'
-)
-
-
-plt.pcolormesh(grams[0])
-plt.ylabel('Frequency [Hz]')
-plt.xlabel('Time ')
-plt.savefig('fig.png')
 
 

--- a/src/acoustic_util.py
+++ b/src/acoustic_util.py
@@ -1,12 +1,14 @@
+import os
+import datetime
+
 import librosa
 import librosa.display
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 from skimage.restoration import denoise_wavelet
-import os
 import numpy as np
 import pandas as pd
-import datetime
+
 
 
 def apply_per_channel_energy_norm(spectrogram):
@@ -128,6 +130,7 @@ def select_spec_case(plot_path, folder_path, pcen=False, wavelet=False):
             spectrogram_data = wavelet_denoising(pcen_spec)
         spec_plot_and_save(spectrogram_data, f_name, plot_path)
 
+
 def wav_to_array(filepath, t0=datetime.datetime.now(), delta_t=1, delta_f=10, pcen=False, wavelet=False, ref=np.max, bands=None):
     """
     This function converts a wavfile to a dataframe of power spectral density, with the index as the timestamp from the start of the wav file and the columns as the frequency bin.  This function also calculates the broadband average noise level of the input wavefile before the dB conversion per time step after the FFT calculation.  
@@ -189,6 +192,7 @@ def wav_to_array(filepath, t0=datetime.datetime.now(), delta_t=1, delta_f=10, pc
     else:
         return df, rms_df
 
+
 def ancient_ambient(df):
     """
     Ancient ambient noise level is defined as the 5th percentile noise level of a month's acoustic data.  
@@ -199,6 +203,7 @@ def ancient_ambient(df):
     """
 
     return np.percentile(df, 5)
+
 
 def spec_plot(df, sr=48000, hop_length=256):
     """
@@ -223,6 +228,7 @@ def spec_plot(df, sr=48000, hop_length=256):
     fig.gca().xaxis.set_major_locator(mdates.SecondLocator())
     plt.gcf().autofmt_xdate()
 
+
 def filt_gain(f, fm, b):
     """
     f: array of frequencies to apply gain to
@@ -242,6 +248,7 @@ def filt_gain(f, fm, b):
 
     return np.sqrt(np.divide(ones, np.add(ones, h)))
 
+
 def band_power(psd, g, delta_f):
     """
     https://www.ap.com/technical-library/deriving-fractional-octave-spectra-from-the-fft-with-apx/
@@ -253,6 +260,7 @@ def band_power(psd, g, delta_f):
     exp = np.full(len(psd), 2.0)
     x = np.multiply(psd, np.power(g, exp))
     return np.sqrt(delta_f*np.sum(x))
+
 
 def octave_band(N, freqs):
     """
@@ -346,6 +354,7 @@ def octave_band(N, freqs):
         raise ValueError
     else:
         return bands[N], filters[N]
+
 
 def spec_to_bands(psd, N, delta_f, freqs, ref):
     """

--- a/src/acoustic_util.py
+++ b/src/acoustic_util.py
@@ -136,8 +136,7 @@ def wav_to_array(filepath,
                  delta_t=1, 
                  delta_f=10, 
                  transforms=[
-                    librosa.core.pcen, 
-                    denoise_wavelet
+                    wavelet_denoising
                 ], 
                 ref=np.max,
                 bands=None

--- a/src/acoustic_util.py
+++ b/src/acoustic_util.py
@@ -151,11 +151,12 @@ def wav_to_array(filepath,
     Args:
         filepath: file path to .wav
         to: datetime.  starting time of the recording. 
-        hop_length: int. number of audio samples between adjacent STFT columns.  See librosa docs for more info. 
+        delta_t: Int, number of seconds per sample
+        delta_f: Int, number of hz per frequency band
         n_fft: int. number of points in the acquired time-domain signal.  delta F = sample rate/n_fft
         transforms: List of functions to apply to DB-spectogram before reducing to bands. Functions must take in single spectogram as argument and return same. Default is to apply PCEN and wavelet denoising.
         ref: float.  reference level for the amplitude to dB conversion.  must be an absolute value, not dB. 
-        bands: Octave bands to generate
+        bands: Octave bands to generate # TODO: What format?
 
     Returns:
         Tuple of (df1, df2)

--- a/src/acoustic_util.py
+++ b/src/acoustic_util.py
@@ -379,3 +379,26 @@ def spec_to_bands(psd, N, delta_f, freqs, ref):
     octaves_scaled = librosa.amplitude_to_db(octaves, ref=ref)
 
     return octaves_scaled, bands
+
+def plot_noise(testdf, name, output_path=None, save = False):
+    fig, ax = plt.subplots()
+    spec = ax.pcolormesh(testdf.index, testdf.columns, testdf.values.transpose())
+    ax.set_yscale('log')
+    ax.set_ylim([50, 20000])
+    fig.autofmt_xdate(rotation=45)
+    fig.gca().xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
+    #fig.gca().xaxis.set_major_locator(mdates.SecondLocater())
+    fig.colorbar(spec,ax=ax, label="dB relative to ancient ambient")
+    fig.set_size_inches(10, 10)
+    plt.title(name)
+    # os.chdir(plotPath)
+    if save:
+        fig.savefig(output_path,
+                    dpi=80,
+                    bbox_inches="tight",
+                    pad_inches=0.0)
+        
+        fig.canvas.draw()
+        fig.canvas.flush_events()
+        plt.close(fig)
+    

--- a/src/acoustic_util.py
+++ b/src/acoustic_util.py
@@ -153,9 +153,12 @@ def wav_to_array(filepath,
         delta_t: Int, number of seconds per sample
         delta_f: Int, number of hz per frequency band
         n_fft: int. number of points in the acquired time-domain signal.  delta F = sample rate/n_fft
-        transforms: List of functions to apply to DB-spectogram before reducing to bands. Functions must take in single spectogram as argument and return same. Default is to apply PCEN and wavelet denoising.
+        transforms: List of functions to apply to DB-spectogram before reducing to bands. 
+          Functions must take in single spectogram as argument and return same. Default is to apply PCEN and wavelet denoising.
         ref: float.  reference level for the amplitude to dB conversion.  must be an absolute value, not dB. 
-        bands: Octave bands to generate # TODO: What format?
+        bands: int. default=None. If not None this value selects how many octave subdivisions the frequency spectrum should 
+          be divided into, where each frequency step is 1/Nth of an octave with N=bands. Based on the ISO R series.
+          Accepts values 1, 3, 6, 12, or 24.
 
     Returns:
         Tuple of (df1, df2)

--- a/src/file_connector.py
+++ b/src/file_connector.py
@@ -1,34 +1,23 @@
 import datetime as dt
 import logging
-from enum import Enum
 
 import boto3
 from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
-     
-class Bucket(Enum):
-    """
-    Enum for orcasound AWS S3 Buckets
-    """
-
-    BUSH_POINT = ("streaming-orcasound-net", "rpi_bush_point")
-    ORCASOUND_LAB = ("streaming-orcasound-net", "rpi_orcasound_lab")
-    PORT_TOWNSEND = ("streaming-orcasound-net", "rpi_port_townsend")
-    SUNSET_BAY = ("streaming-orcasound-net", "rpi_sunset_bay")
-    SANDBOX = ("acoustic-sandbox", "orcasounds")
+from .hydrophone import Hydrophone
 
 class S3FileConnector:
 
     DT_FORMAT = "%Y%m%dT%H%M%S"
 
-    def __init__(self, bucket: Bucket):
+    def __init__(self, hydrophone: Hydrophone):
         """
         S3File Connector maintains a connection to an AWS s3 bucket.
         """
-        self.bucket = bucket.value[0]
-        self.ref_folder = bucket.value[1]
+        self.bucket = hydrophone.value.bucket
+        self.ref_folder = hydrophone.value.ref_folder
         self.client = boto3.client('s3', config=Config(signature_version=UNSIGNED))
         self.resource = boto3.resource('s3', config=Config(signature_version=UNSIGNED)).Bucket(self.bucket)
 

--- a/src/file_connector.py
+++ b/src/file_connector.py
@@ -18,6 +18,9 @@ class S3FileConnector:
         """
         self.bucket = hydrophone.value.bucket
         self.ref_folder = hydrophone.value.ref_folder
+        self.save_bucket = hydrophone.value.save_bucket
+        self.save_folder = hydrophone.value.save_folder
+
         self.client = boto3.client('s3', config=Config(signature_version=UNSIGNED))
         self.resource = boto3.resource('s3', config=Config(signature_version=UNSIGNED)).Bucket(self.bucket)
 
@@ -77,7 +80,7 @@ class S3FileConnector:
             opened_file = False
         
         try:
-            response = self.client.upload_fileobj(file, self.bucket.value, file_name)
+            response = self.client.upload_fileobj(file, self.save_bucket, self.save_folder + "/" + file_name)
         except ClientError as e:
             logging.error(e)
             return False

--- a/src/hydrophone.py
+++ b/src/hydrophone.py
@@ -1,0 +1,15 @@
+from enum import Enum
+from collections import namedtuple
+
+class Hydrophone(Enum):
+    """
+    Enum for orcasound hydrophones, including AWS S3 Bucket info
+    """
+
+    HPhoneTup = namedtuple("Hydrophone", "bucket ref_folder")
+
+    BUSH_POINT = HPhoneTup("streaming-orcasound-net", "rpi_bush_point")
+    ORCASOUND_LAB = HPhoneTup("streaming-orcasound-net", "rpi_orcasound_lab")
+    PORT_TOWNSEND = HPhoneTup("streaming-orcasound-net", "rpi_port_townsend")
+    SUNSET_BAY = HPhoneTup("streaming-orcasound-net", "rpi_sunset_bay")
+    SANDBOX = HPhoneTup("acoustic-sandbox", "orcasounds")

--- a/src/hydrophone.py
+++ b/src/hydrophone.py
@@ -6,10 +6,10 @@ class Hydrophone(Enum):
     Enum for orcasound hydrophones, including AWS S3 Bucket info
     """
 
-    HPhoneTup = namedtuple("Hydrophone", "name bucket ref_folder")
+    HPhoneTup = namedtuple("Hydrophone", "name bucket ref_folder save_bucket save_folder")
 
-    BUSH_POINT = HPhoneTup("bush_point", "streaming-orcasound-net", "rpi_bush_point")
-    ORCASOUND_LAB = HPhoneTup("orcasound_lab", "streaming-orcasound-net", "rpi_orcasound_lab")
-    PORT_TOWNSEND = HPhoneTup("port_townsend", "streaming-orcasound-net", "rpi_port_townsend")
-    SUNSET_BAY = HPhoneTup("sunset_bay", "streaming-orcasound-net", "rpi_sunset_bay")
-    SANDBOX = HPhoneTup("sandbox", "acoustic-sandbox", "orcasounds")
+    BUSH_POINT = HPhoneTup("bush_point", "streaming-orcasound-net", "rpi_bush_point", "acoustic-sandbox", "bush_point")
+    ORCASOUND_LAB = HPhoneTup("orcasound_lab", "streaming-orcasound-net", "rpi_orcasound_lab", "acoustic-sandbox", "orcasound_lab")
+    PORT_TOWNSEND = HPhoneTup("port_townsend", "streaming-orcasound-net", "rpi_port_townsend", "acoustic-sandbox", "port_townsend")
+    SUNSET_BAY = HPhoneTup("sunset_bay", "streaming-orcasound-net", "rpi_sunset_bay", "acoustic-sandbox", "sunset_bay")
+    SANDBOX = HPhoneTup("sandbox", "acoustic-sandbox", "orcasounds", "acoustic-sandbox", "orcasounds")

--- a/src/hydrophone.py
+++ b/src/hydrophone.py
@@ -6,7 +6,7 @@ class Hydrophone(Enum):
     Enum for orcasound hydrophones, including AWS S3 Bucket info
     """
 
-    HPhoneTup = namedtuple("Hydrophone", "name bucket", "ref_folder")
+    HPhoneTup = namedtuple("Hydrophone", "name bucket ref_folder")
 
     BUSH_POINT = HPhoneTup("bush_point", "streaming-orcasound-net", "rpi_bush_point")
     ORCASOUND_LAB = HPhoneTup("orcasound_lab", "streaming-orcasound-net", "rpi_orcasound_lab")

--- a/src/hydrophone.py
+++ b/src/hydrophone.py
@@ -6,10 +6,10 @@ class Hydrophone(Enum):
     Enum for orcasound hydrophones, including AWS S3 Bucket info
     """
 
-    HPhoneTup = namedtuple("Hydrophone", "bucket ref_folder")
+    HPhoneTup = namedtuple("Hydrophone", "name bucket ref_folder")
 
-    BUSH_POINT = HPhoneTup("streaming-orcasound-net", "rpi_bush_point")
-    ORCASOUND_LAB = HPhoneTup("streaming-orcasound-net", "rpi_orcasound_lab")
-    PORT_TOWNSEND = HPhoneTup("streaming-orcasound-net", "rpi_port_townsend")
-    SUNSET_BAY = HPhoneTup("streaming-orcasound-net", "rpi_sunset_bay")
-    SANDBOX = HPhoneTup("acoustic-sandbox", "orcasounds")
+    BUSH_POINT = HPhoneTup("bush_point", "streaming-orcasound-net", "rpi_bush_point")
+    ORCASOUND_LAB = HPhoneTup("orcasound_lab", "streaming-orcasound-net", "rpi_orcasound_lab")
+    PORT_TOWNSEND = HPhoneTup("port_townsend", "streaming-orcasound-net", "rpi_port_townsend")
+    SUNSET_BAY = HPhoneTup("sunset_bay", "streaming-orcasound-net", "rpi_sunset_bay")
+    SANDBOX = HPhoneTup("sandbox", "acoustic-sandbox", "orcasounds")

--- a/src/hydrophone.py
+++ b/src/hydrophone.py
@@ -6,7 +6,7 @@ class Hydrophone(Enum):
     Enum for orcasound hydrophones, including AWS S3 Bucket info
     """
 
-    HPhoneTup = namedtuple("Hydrophone", "name bucket ref_folder")
+    HPhoneTup = namedtuple("Hydrophone", "name bucket", "ref_folder")
 
     BUSH_POINT = HPhoneTup("bush_point", "streaming-orcasound-net", "rpi_bush_point")
     ORCASOUND_LAB = HPhoneTup("orcasound_lab", "streaming-orcasound-net", "rpi_orcasound_lab")

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -18,14 +18,16 @@ from .file_connector import S3FileConnector
 
 class NoiseAnalysisPipeline:
 
-    def __init__(self, hydrophone: Hydrophone, delta_f, delta_t, bands=None, wav_folder=None, pqt_folder=None, ):
+    def __init__(self, hydrophone: Hydrophone, delta_f, delta_t, bands=None, wav_folder=None, pqt_folder=None):
         """
         Pipeline object for generating rolled-up PDS parquet files. 
 
         * hydrophone: Hydrophone enum that contains all conenction info to S3 buccket.
         * wav_folder: Local folder to store wav files in. Defaults to Temporary Directory
         * pqt_folder: Local folder to store pqt files in. Defaults to Temporary Directory
-        * bands: The octave bands to reduce each PDS to.
+        * delta_f: The number of hertz per band
+        * delta_t: The number of seconds per sample
+        * bands: #TODO: What do bands do?
         """
 
         # Conenctions

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,101 +1,160 @@
 # Native imports
 import datetime as dt
+import os
+import tempfile
 import time
 
 # Third part imports
 import numpy as np
+import pandas as pd
 from scipy import signal
 from scipy.io import wavfile
 
 # Local imports
 from orca_hls_utils.DateRangeHLSStream import DateRangeHLSStream
-from util import wav_to_array
+from .acoustic_util import wav_to_array
+from .hydrophone import Hydrophone
+from .file_connector import S3FileConnector
 
-def ts_to_spectrogram(start_date: dt.date, end_date: dt.date, wav_folder, max_files=5):
-    """
-    Pull ts files from aws and create spectrograms of them by converting to wav files.
+class NoiseAnalysisPipeline:
 
-    * start_date: First date to pull files for
-    * end_date: Last date to collect files for
-    * wav_folder: folder path to store wav files in
-    * max_files: Maximum number of wav files to generate. Use to help limit compute and egress whiel testing.
+    def __init__(self, hydrophone: Hydrophone, wav_folder=None, pqt_folder=None):
+        """
+        Pipeline object for generating rolled-up PDS parquet files. 
 
-    # Return
+        * hydrophone: Hydrophone enum that contains all conenction info to S3 buccket.
+        * wav_folder: Local folder to store wav files in. Defaults to Temporary Directory
+        * pqt_folder: Local folder to store pqt files in. Defaults to Temporary Directory
+        """
 
-    List of spectrograms, one per wav file generated
+        # Conenctions
+        self.hydrophone = hydrophone.value
+        self.file_connector = S3FileConnector(hydrophone)
 
-    """
+        # Local storage
+        if wav_folder:
+            self.wav_folder = wav_folder
+            self.wav_folder_td = None
+        else:
+            self.wav_folder_td = tempfile.TemporaryDirectory()
+            self.wav_folder = self.wav_folder_td.name
+        
+        if pqt_folder:
+            self.pqt_folder = pqt_folder
+            self.pqt_folder_td = None
+        else:
+            self.pqt_folder_td = tempfile.TemporaryDirectory()
+            self.pqt_folder = self.pqt_folder_td.name
 
-    stream = DateRangeHLSStream(
-        'https://s3-us-west-2.amazonaws.com/streaming-orcasound-net/rpi_orcasound_lab',
-        60,
-        time.mktime(start_date.timetuple()),
-        time.mktime(end_date.timetuple()),
-        wav_folder
-    )
+    def __del__(self):
+        """"
+        Remove Temp Dirs on delete
+        """
 
-    result = []
-    while len(result) <= max_files and not stream.is_stream_over():
-        wav_file_path, clip_start_time, current_clip_name = stream.get_next_clip()
-        frequencies, times, spectrogram = create_spectogram(wav_file_path)
-        result.append(spectrogram)
+        try:
+            self.wav_folder_td.cleanup()
+        except AttributeError:
+            pass
+        try:
+            self.pqt_folder_td.cleanup()
+        except AttributeError:
+            pass
 
-    return result
+    # TODO
+    def get_data(hydrophone: str, target_date: dt.date, sec_per_sample=60, frequency_bands='octet', check_archive=True, if_missing='raise'):
+        """
+        Gets a days worth of pds data from target hydrophone.
 
+        * hydrophone: String name of hydrophone. Names include [rpi-orcasound-lab, bush-point...]
+        * target_date. Date to pull data for
+        * sec_per_sample: The number of seconds per row of data. Default is one minute per sample.
+        * frequency_bands: The bands of frequency in the result. CHoose from premade bands such as 'octet', 'thirds', 'octet-log' or enter an integer to specify the number of hz per band
+        * check_archive: Flag for whether to look in the archive before generating this data. Defaults to True.
+        * if_missing: Behavior to take if no archive data is available. Set to 'raise' to raise a lookupError for missing data, 'generate' to create a new pds with the specifications 
+            if none exists, or 'ignore' to return an empty dataframe. Has no effect if chack_archive is set to False.
 
-def ts_to_array(start_date: dt.date, end_date: dt.date, wav_folder, max_files=6, overwrite_output=False, **kwargs):
-    """
-    Pull ts files from aws and create PSD arrays of them by converting to wav files.
+        # Return
+        Dataframe representing one days worth of psd data at desired specs. Rows are timestamps, columns are frequency bands.
+        
+        """
 
-    * start_date: First date to pull files for
-    * end_date: Last date to collect files for
-    * wav_folder: folder path to store wav files in
-    * max_files: Maximum number of wav files to generate. Use to help limit compute and egress whiel testing.
-    * overwrite_output: Automatically overwrite existing wav files. If False, will prompt before overwriting
-    * kwargs: Other keyword args are passed to wav_to_array
+        # TODO
 
-    # Return
+    def generate_psds(self, start: dt.datetime, end: dt.datetime, max_files=6, overwrite_output=False, **kwargs):
+        """
+        Pull ts files from aws and create PSD arrays of them by converting to wav files.
 
-    List of PSDs, one per wav file generated
+        * start_date: First date to pull files for
+        * end_date: Last date to collect files for
+        * max_files: Maximum number of wav files to generate. Use to help limit compute and egress whiel testing.
+        * overwrite_output: Automatically overwrite existing wav files. If False, will prompt before overwriting
+        * kwargs: Other keyword args are passed to wav_to_array
 
-    """
+        # Return
 
-    stream = DateRangeHLSStream(
-        'https://s3-us-west-2.amazonaws.com/streaming-orcasound-net/rpi_orcasound_lab',
-        60,
-        time.mktime(start_date.timetuple()),
-        time.mktime(end_date.timetuple()),
-        wav_folder,
-        overwrite_output
-    )
+        List of PSDs, one per wav file generated
 
-    result = []
-    while len(result) < max_files and not stream.is_stream_over():
-        wav_file_path, clip_start_time, current_clip_name = stream.get_next_clip()
-        if wav_file_path is not None:
-            df = wav_to_array(wav_file_path, **kwargs)
-            result.append(df)
+        """
 
-    return result
+        stream = DateRangeHLSStream(
+            'https://s3-us-west-2.amazonaws.com/' + self.hydrophone.bucket + '/' + self.hydrophone.ref_folder,
+            60,
+            time.mktime(start.timetuple()),
+            time.mktime(end.timetuple()),
+            self.wav_folder,
+            overwrite_output
+        )
 
+        result = []
+        while len(result) < max_files and not stream.is_stream_over():
+            wav_file_path, clip_start_time, current_clip_name = stream.get_next_clip()
+            if wav_file_path is not None:
+                df = wav_to_array(wav_file_path, **kwargs)
+                result.append(df)
 
+        return result
 
-def create_spectogram(file):
-    """
-    Create a spectrogram from a wav file.
+    def generate_parquet_file(self, start: dt.datetime, end: dt.datetime, pqt_folder_override=None, upload_to_s3=False):
+        """
+        Create a parquet file of the psd at the given daterange.
 
-    * file: File handle or path of wav file
-    * sample_rate: Rate in samples per second. Leave as none to use the sample rate of the wav file
+        * Start: datetime, start of data to poll
+        * end: datetime, end of data to poll
+        * pqt_folder_override: Overide the object level settings for where to save pqt files.
+        * upload_to_s3: Boolean, set to true to upload file to S3 after saving
+        """
 
-    # Return
+        # Create datafame
+        psds = self.generate_psds(start, end, overwrite_output=True)
+        pds_frame = pd.concat(list(zip(*psds))[0])
 
-    Tuple of frequencies, times, spectrogram
-    """
-    sample_rate, samples = wavfile.read(file)
+        # Save file
+        save_folder = pqt_folder_override or self.pqt_folder
+        os.makedirs(save_folder, exist_ok=True)
+        fileName = self.file_connector.create_filename(start, end, 1, '3rd-octet')
+        filePath = os.path.join(save_folder, fileName)
+        pds_frame.to_parquet(filePath)
 
-    # Average channels if more than 1
-    if len(samples.shape) > 1 and samples.shape[1] > 1:
-        samples = np.mean(samples, axis=1)
+        # Upload
+        if upload_to_s3:
+            self.file_connector.upload_file(filePath, start, end, 1, '3rd-octet')
 
-    frequencies, times, spectrogram = signal.spectrogram(samples, sample_rate)
-    return frequencies, times, spectrogram
+    def create_spectogram(file):
+        """
+        Create a spectrogram from a wav file.
+
+        * file: File handle or path of wav file
+        * sample_rate: Rate in samples per second. Leave as none to use the sample rate of the wav file
+
+        # Return
+
+        Tuple of frequencies, times, spectrogram
+        """
+        sample_rate, samples = wavfile.read(file)
+
+        # Average channels if more than 1
+        if len(samples.shape) > 1 and samples.shape[1] > 1:
+            samples = np.mean(samples, axis=1)
+
+        frequencies, times, spectrogram = signal.spectrogram(samples, sample_rate)
+        return frequencies, times, spectrogram

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -128,6 +128,9 @@ class NoiseAnalysisPipeline:
         * end: datetime, end of data to poll
         * pqt_folder_override: Overide the object level settings for where to save pqt files.
         * upload_to_s3: Boolean, set to true to upload file to S3 after saving
+
+        # Return
+        Filepath of generated pqt file.
         """
 
         # Create datafame
@@ -144,6 +147,8 @@ class NoiseAnalysisPipeline:
         # Upload
         if upload_to_s3:
             self.file_connector.upload_file(filePath, start, end, self.delta_t, self.delta_f)
+
+        return filePath
 
     def create_spectogram(file):
         """

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -27,7 +27,9 @@ class NoiseAnalysisPipeline:
         * pqt_folder: Local folder to store pqt files in. Defaults to Temporary Directory
         * delta_f: The number of hertz per band
         * delta_t: The number of seconds per sample
-        * bands: #TODO: What do bands do?
+        * bands: int. default=None. If not None this value selects how many octave subdivisions the frequency spectrum should 
+          be divided into, where each frequency step is 1/Nth of an octave with N=bands. Based on the ISO R series.
+          Accepts values 1, 3, 6, 12, or 24.
         """
 
         # Conenctions

--- a/tests/test_FileConnector.py
+++ b/tests/test_FileConnector.py
@@ -19,5 +19,6 @@ def test_parse_filename():
         dt.datetime(2023, 1, 1, 6, 30),
         dt.datetime(2023, 1, 1, 12, 30),
         60,
-        100
+        100,
+        "delta_hz"
     ]


### PR DESCRIPTION
Converts pipeline to object for ease of variable sharing and parallelization. See example.py for usage.

- Convert pipeline to object
- Create Hydrophone enum to store hydrophone connection info in consistent manner
- Move util into src folder and rename accoustic-util
- Change wav_to_array to take a list of transforms instead of boolean flags.