### PR TITLE
Psd file partitioning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.11
   - ffmpeg=8.0.0
+  # Requires AWS CLI on PATH for upload_partitioned_folder (external install).
   - pip
   - pip:
       - -e .

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -277,7 +277,7 @@ class NoiseAnalysisPipeline:
             psd_frame['type'] = 'psd'
 
             psd_frame.to_parquet(
-                save_folder / s3_save_folder,
+                save_folder + '/' + s3_save_folder,
                 partition_cols=['year', 'month', 'day', 'hydrophone', 'type'],
                 engine='pyarrow',
                 index=True,
@@ -290,14 +290,14 @@ class NoiseAnalysisPipeline:
             broadband_frame['type'] = 'broadband'
 
             broadband_frame.to_parquet(
-                save_folder / s3_save_folder,
+                save_folder + '/' + s3_save_folder,
                 partition_cols=['year', 'month', 'day', 'hydrophone', 'type'],
                 engine='pyarrow',
                 index=True,
                 )
             
             if upload_to_s3:
-                self.file_connector.upload_partitioned_folder(save_folder / s3_save_folder)
+                self.file_connector.upload_partitioned_folder(save_folder + '/' + s3_save_folder)
 
             return os.path.join(save_folder, s3_save_folder)
         

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -5,7 +5,6 @@ import tempfile
 import time
 import logging
 import random
-from pathlib import Path
 
 
 # Third part imports

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -274,10 +274,11 @@ class NoiseAnalysisPipeline:
             psd_frame['month'] = psd_frame.index.strftime('%m')
             psd_frame['year'] = psd_frame.index.strftime('%Y')
             psd_frame['hydrophone'] = self.hydrophone.name
+            psd_frame.columns = psd_frame.columns.astype(str)
 
             psd_frame.to_parquet(
-                save_folder + '/' + s3_save_folder + '/psd',
-                partition_cols=['hydrophone','year', 'month', 'day'],
+                os.path.join(save_folder, s3_save_folder, 'psd'),
+                partition_cols=['hydrophone' ,'year', 'month', 'day'],
                 engine='pyarrow',
                 index=True,
                 )
@@ -286,18 +287,19 @@ class NoiseAnalysisPipeline:
             broadband_frame['month'] = broadband_frame.index.strftime('%m')
             broadband_frame['year'] = broadband_frame.index.strftime('%Y')
             broadband_frame['hydrophone'] = self.hydrophone.name
+            broadband_frame.columns = broadband_frame.columns.astype(str)
 
             broadband_frame.to_parquet(
-                save_folder + '/' + s3_save_folder + '/broadband',
-                partition_cols=['hydrophone','year', 'month', 'day'],
+                os.path.join(save_folder, s3_save_folder, 'broadband'),
+                partition_cols=['hydrophone' ,'year', 'month', 'day'],
                 engine='pyarrow',
                 index=True,
                 )
             
             if upload_to_s3:
-                self.file_connector.upload_partitioned_folder(save_folder + '/' + s3_save_folder)
+                self.file_connector.upload_partitioned_folder(os.path.join(save_folder, s3_save_folder))
 
-            return os.path.join(save_folder, s3_save_folder)
+            return os.path.join(save_folder, s3_save_folder, 'psd'), os.path.join(save_folder, s3_save_folder, 'broadband')
         
         # Non-partitioned save
         filePath = os.path.join(save_folder, fileName)

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -274,11 +274,10 @@ class NoiseAnalysisPipeline:
             psd_frame['month'] = psd_frame.index.strftime('%m')
             psd_frame['year'] = psd_frame.index.strftime('%Y')
             psd_frame['hydrophone'] = self.hydrophone.name
-            psd_frame['type'] = 'psd'
 
             psd_frame.to_parquet(
-                save_folder + '/' + s3_save_folder,
-                partition_cols=['year', 'month', 'day', 'hydrophone', 'type'],
+                save_folder + '/' + s3_save_folder + '/psd',
+                partition_cols=['hydrophone','year', 'month', 'day'],
                 engine='pyarrow',
                 index=True,
                 )
@@ -287,11 +286,10 @@ class NoiseAnalysisPipeline:
             broadband_frame['month'] = broadband_frame.index.strftime('%m')
             broadband_frame['year'] = broadband_frame.index.strftime('%Y')
             broadband_frame['hydrophone'] = self.hydrophone.name
-            broadband_frame['type'] = 'broadband'
 
             broadband_frame.to_parquet(
-                save_folder + '/' + s3_save_folder,
-                partition_cols=['year', 'month', 'day', 'hydrophone', 'type'],
+                save_folder + '/' + s3_save_folder + '/broadband',
+                partition_cols=['hydrophone','year', 'month', 'day'],
                 engine='pyarrow',
                 index=True,
                 )

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -5,6 +5,7 @@ import tempfile
 import time
 import logging
 import random
+from pathlib import Path
 
 
 # Third part imports
@@ -238,7 +239,7 @@ class NoiseAnalysisPipeline:
             raise ValueError("Specify either 'safe' or 'fast' mode")
 
     def generate_parquet_file(self, start: dt.datetime, end: dt.datetime, pqt_folder_override=None,
-                              upload_to_s3=False):
+                              upload_to_s3=False, partitioning=False):
         """
         Create a parquet file of the psd at the given daterange.
 
@@ -246,28 +247,66 @@ class NoiseAnalysisPipeline:
         * end: datetime, end of data to poll
         * pqt_folder_override: Overide the object level settings for where to save pqt files.
         * upload_to_s3: Boolean, set to true to upload file to S3 after saving
+        * partitioning: Boolean, set to true to partition parquet file by year, month, day, hydrophone, type (PSD or BB)
 
         # Return
         Filepath of generated pqt file.
         """
 
         # Create PSD and broadband Dataframes
-        pds_frame, broadband_frame = self.generate_psds(start, end, overwrite_output=True)
+        psd_frame, broadband_frame = self.generate_psds(start, end, overwrite_output=True)
 
-        if pds_frame is None:
+        if psd_frame is None:
             return None, None
 
-        # Save file locally
+        # Save file locally or into temp dir
         save_folder = pqt_folder_override or self.pqt_folder
+        # fetch s3 save folder from hydrophone enum for s3 upload path
+        s3_save_folder = self.hydrophone.save_folder
         os.makedirs(save_folder, exist_ok=True)
+
         fileName = self.file_connector.create_filename(start, end, self.delta_t, self.delta_f,
                                                        octave_bands=self.bands)
         broadbandName = self.file_connector.create_filename(start, end, self.delta_t, is_broadband=True)
+
+        if partitioning:
+            psd_frame['day'] = psd_frame.index.strftime('%d')
+            psd_frame['month'] = psd_frame.index.strftime('%m')
+            psd_frame['year'] = psd_frame.index.strftime('%Y')
+            psd_frame['hydrophone'] = self.hydrophone.name
+            psd_frame['type'] = 'psd'
+
+            psd_frame.to_parquet(
+                save_folder / s3_save_folder,
+                partition_cols=['year', 'month', 'day', 'hydrophone', 'type'],
+                engine='pyarrow',
+                index=True,
+                )
+
+            broadband_frame['day'] = broadband_frame.index.strftime('%d')
+            broadband_frame['month'] = broadband_frame.index.strftime('%m')
+            broadband_frame['year'] = broadband_frame.index.strftime('%Y')
+            broadband_frame['hydrophone'] = self.hydrophone.name
+            broadband_frame['type'] = 'broadband'
+
+            broadband_frame.to_parquet(
+                save_folder / s3_save_folder,
+                partition_cols=['year', 'month', 'day', 'hydrophone', 'type'],
+                engine='pyarrow',
+                index=True,
+                )
+            
+            if upload_to_s3:
+                self.file_connector.upload_partitioned_folder(save_folder / s3_save_folder)
+
+            return os.path.join(save_folder, s3_save_folder)
+        
+        # Non-partitioned save
         filePath = os.path.join(save_folder, fileName)
         broadbandFilePath = os.path.join(save_folder, broadbandName)
-        pds_frame.columns = pds_frame.columns.astype(str)
+        psd_frame.columns = psd_frame.columns.astype(str)
         broadband_frame.columns = broadband_frame.columns.astype(str)
-        pds_frame.to_parquet(filePath)
+        psd_frame.to_parquet(filePath)
         broadband_frame.to_parquet(broadbandFilePath)
 
         # Upload to S3 bucket

--- a/src/orcasound_noise/utils/file_connector.py
+++ b/src/orcasound_noise/utils/file_connector.py
@@ -1,11 +1,13 @@
 import datetime as dt
 import logging
+import io
+import os
+import subprocess
 
 import boto3
 from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import ClientError
-from dotenv import load_dotenv
 
 from .hydrophone import Hydrophone
 
@@ -13,10 +15,24 @@ class S3FileConnector:
 
     DT_FORMAT = "%Y%m%dT%H%M%S"
 
-    def __init__(self, hydrophone: Hydrophone, no_sign=False):
+    def __init__(self, hydrophone: Hydrophone, no_sign=False, env_file: str = None):
         """
         S3File Connector maintains a connection to an AWS s3 bucket.
+        
+        Args:
+            hydrophone: Hydrophone enum value
+            no_sign: If True, use unsigned requests. If False, use AWS credentials from environment
+            env_file: Optional path to .env file for local development. If provided, environment 
+                     variables will be loaded from this file. Not recommended for production.
         """
+        # Load environment variables from file if provided (for local development)
+        if env_file:
+            try:
+                from dotenv import load_dotenv
+                load_dotenv(env_file)
+            except ImportError:
+                logging.warning(f"dotenv not installed. Unable to load {env_file}. "
+                                "Relying on OS environment variables.")
         self.bucket = hydrophone.value.bucket
         self.ref_folder = hydrophone.value.ref_folder
         self.save_bucket = hydrophone.value.save_bucket
@@ -27,7 +43,8 @@ class S3FileConnector:
             self.source_resource = boto3.resource('s3', config=Config(signature_version=UNSIGNED)).Bucket(self.bucket)
             self.archive_resource = boto3.resource('s3', config=Config(signature_version=UNSIGNED)).Bucket(self.save_bucket)
         else:
-            load_dotenv('.aws-config')
+            # boto3 automatically looks for credentials in environment variables
+            # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, or AWS_SESSION_TOKEN
             self.client = boto3.client('s3')
             self.source_resource = boto3.resource('s3').Bucket(self.bucket)
             self.archive_resource = boto3.resource('s3').Bucket(self.save_bucket)
@@ -112,6 +129,24 @@ class S3FileConnector:
         finally:
             if opened_file:
                 file.close()
+
+    def upload_partitioned_folder(self, folder_path: str):
+        """
+        Upload a partitioned parquet folder to the S3 archive
+
+        Uses AWS CLI to perform the upload to handle partitioned folders and upload only new files.
+
+        * folder_path: Path to the local folder containing partitioned parquet files, folder path needs to include S3 key prefix
+        """
+        if self.save_folder not in folder_path:
+            raise ValueError(f"folder_path must include '{self.save_folder}' to match S3 key prefix.")
+        
+        # Use AWS CLI to sync folder to S3
+        subprocess.run([
+            "aws", "s3", "sync",
+            folder_path, f"s3://{self.save_bucket}/{self.save_folder}/",
+            "--no-overwrite"
+        ], check=True)
 
     def get_files(self, start: dt.datetime, end: dt.datetime, secs_per_sample: int, hz_bands=None, is_broadband=False):
         """

--- a/src/orcasound_noise/utils/file_connector.py
+++ b/src/orcasound_noise/utils/file_connector.py
@@ -1,7 +1,5 @@
 import datetime as dt
 import logging
-import io
-import os
 import subprocess
 
 import boto3
@@ -135,18 +133,50 @@ class S3FileConnector:
         Upload a partitioned parquet folder to the S3 archive
 
         Uses AWS CLI to perform the upload to handle partitioned folders and upload only new files.
+        Requires the `aws` CLI to be installed and available on PATH.
 
-        * folder_path: Path to the local folder containing partitioned parquet files, folder path needs to include S3 key prefix
+        * folder_path: Path to the local folder containing partitioned parquet files.
+          The local folder path must include the S3 key prefix used by this connector
+          (i.e. ``self.save_folder``) so that the local partition hierarchy matches
+          the S3 key structure.
+          For example, if:
+            - ``self.save_bucket = "orcasound-noise"``
+            - ``self.save_folder = "ambient-sound-analysis/data/"``
+          then a valid ``folder_path`` could be::
+              /local/path/ambient-sound-analysis/data/
+            or::
+              /local/path/ambient-sound-analysis/data/hydrophone=orcasound_lab/year=2023
+          In general, ``folder_path`` should contain ``self.save_folder`` as a substring.
         """
         if self.save_folder not in folder_path:
             raise ValueError(f"folder_path must include '{self.save_folder}' to match S3 key prefix.")
         
         # Use AWS CLI to sync folder to S3
-        subprocess.run([
-            "aws", "s3", "sync",
-            folder_path, f"s3://{self.save_bucket}/{self.save_folder}/",
-            "--no-overwrite"
-        ], check=True)
+        try:
+            subprocess.run(
+                [
+                    "aws", "s3", "sync",
+                    folder_path, f"s3://{self.save_bucket}/{self.save_folder}/",
+                    "--no-overwrite",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            logging.error(
+                "AWS CLI is not installed or not found in PATH. "
+                "Please install and configure the AWS CLI to use upload_partitioned_folder."
+            )
+            raise
+        except subprocess.CalledProcessError as exc:
+            logging.error(
+                "AWS CLI sync command failed with return code %s.\nStdout:\n%s\nStderr:\n%s",
+                exc.returncode,
+                exc.stdout,
+                exc.stderr,
+            )
+            raise
 
     def get_files(self, start: dt.datetime, end: dt.datetime, secs_per_sample: int, hz_bands=None, is_broadband=False):
         """

--- a/src/orcasound_noise/utils/hydrophone.py
+++ b/src/orcasound_noise/utils/hydrophone.py
@@ -8,8 +8,8 @@ class Hydrophone(Enum):
 
     HPhoneTup = namedtuple("Hydrophone", "name bucket ref_folder save_bucket save_folder bb_ref")
 
-    BUSH_POINT = HPhoneTup("bush_point", "audio-orcasound-net", "rpi_bush_point", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)
-    ORCASOUND_LAB = HPhoneTup("orcasound_lab", "audio-orcasound-net", "rpi_orcasound_lab", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)
-    PORT_TOWNSEND = HPhoneTup("port_townsend", "audio-orcasound-net", "rpi_port_townsend", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)
-    SUNSET_BAY = HPhoneTup("sunset_bay", "audio-orcasound-net", "rpi_sunset_bay", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)
-    SANDBOX = HPhoneTup("sandbox", "acoustic-sandbox", "ambient-sound-analysis", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)
+    BUSH_POINT = HPhoneTup("bush_point", "audio-orcasound-net", "rpi_bush_point", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)
+    ORCASOUND_LAB = HPhoneTup("orcasound_lab", "audio-orcasound-net", "rpi_orcasound_lab", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)
+    PORT_TOWNSEND = HPhoneTup("port_townsend", "audio-orcasound-net", "rpi_port_townsend", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)
+    SUNSET_BAY = HPhoneTup("sunset_bay", "audio-orcasound-net", "rpi_sunset_bay", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)
+    SANDBOX = HPhoneTup("sandbox", "acoustic-sandbox", "ambient-sound-analysis", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)

--- a/src/orcasound_noise/utils/hydrophone.py
+++ b/src/orcasound_noise/utils/hydrophone.py
@@ -8,8 +8,8 @@ class Hydrophone(Enum):
 
     HPhoneTup = namedtuple("Hydrophone", "name bucket ref_folder save_bucket save_folder bb_ref")
 
-    BUSH_POINT = HPhoneTup("bush_point", "audio-orcasound-net", "rpi_bush_point", "acoustic-sandbox", "ambient-sound-analysis/bush_point", 71.6406580028601)
-    ORCASOUND_LAB = HPhoneTup("orcasound_lab", "audio-orcasound-net", "rpi_orcasound_lab", "acoustic-sandbox", "ambient-sound-analysis/orcasound_lab", 71.6406580028601)
-    PORT_TOWNSEND = HPhoneTup("port_townsend", "audio-orcasound-net", "rpi_port_townsend", "acoustic-sandbox", "ambient-sound-analysis/port_townsend", 71.6406580028601)
-    SUNSET_BAY = HPhoneTup("sunset_bay", "audio-orcasound-net", "rpi_sunset_bay", "acoustic-sandbox", "ambient-sound-analysis/sunset_bay", 71.6406580028601)
+    BUSH_POINT = HPhoneTup("bush_point", "audio-orcasound-net", "rpi_bush_point", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)
+    ORCASOUND_LAB = HPhoneTup("orcasound_lab", "audio-orcasound-net", "rpi_orcasound_lab", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)
+    PORT_TOWNSEND = HPhoneTup("port_townsend", "audio-orcasound-net", "rpi_port_townsend", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)
+    SUNSET_BAY = HPhoneTup("sunset_bay", "audio-orcasound-net", "rpi_sunset_bay", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)
     SANDBOX = HPhoneTup("sandbox", "acoustic-sandbox", "ambient-sound-analysis", "acoustic-sandbox", "ambient-sound-analysis", 71.6406580028601)

--- a/src/orcasound_noise/utils/hydrophone.py
+++ b/src/orcasound_noise/utils/hydrophone.py
@@ -6,10 +6,10 @@ class Hydrophone(Enum):
     Enum for orcasound hydrophones, including AWS S3 Bucket info
     """
 
-    HPhoneTup = namedtuple("Hydrophone", "name bucket ref_folder save_bucket save_folder bb_ref")
+    HPhoneTup = namedtuple("Hydrophone", "name bucket ref_folder save_bucket save_folder bookmark_folder bb_ref")
 
-    BUSH_POINT = HPhoneTup("bush_point", "audio-orcasound-net", "rpi_bush_point", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)
-    ORCASOUND_LAB = HPhoneTup("orcasound_lab", "audio-orcasound-net", "rpi_orcasound_lab", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)
-    PORT_TOWNSEND = HPhoneTup("port_townsend", "audio-orcasound-net", "rpi_port_townsend", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)
-    SUNSET_BAY = HPhoneTup("sunset_bay", "audio-orcasound-net", "rpi_sunset_bay", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)
-    SANDBOX = HPhoneTup("sandbox", "acoustic-sandbox", "ambient-sound-analysis", "acoustic-sandbox", "ambient-sound-analysis/data", 71.6406580028601)
+    BUSH_POINT = HPhoneTup("bush_point", "audio-orcasound-net", "rpi_bush_point", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
+    ORCASOUND_LAB = HPhoneTup("orcasound_lab", "audio-orcasound-net", "rpi_orcasound_lab", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
+    PORT_TOWNSEND = HPhoneTup("port_townsend", "audio-orcasound-net", "rpi_port_townsend", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
+    SUNSET_BAY = HPhoneTup("sunset_bay", "audio-orcasound-net", "rpi_sunset_bay", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
+    SANDBOX = HPhoneTup("sandbox", "acoustic-sandbox", "ambient-sound-analysis", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)

--- a/src/orcasound_noise/utils/hydrophone.py
+++ b/src/orcasound_noise/utils/hydrophone.py
@@ -12,4 +12,8 @@ class Hydrophone(Enum):
     ORCASOUND_LAB = HPhoneTup("orcasound_lab", "audio-orcasound-net", "rpi_orcasound_lab", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
     PORT_TOWNSEND = HPhoneTup("port_townsend", "audio-orcasound-net", "rpi_port_townsend", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
     SUNSET_BAY = HPhoneTup("sunset_bay", "audio-orcasound-net", "rpi_sunset_bay", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
+    ANDREWS_BAY = HPhoneTup("andrews_bay", "audio-orcasound-net", "rpi_andrews_bay", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
+    MAST_CENTER = HPhoneTup("mast_center", "audio-orcasound-net", "rpi_mast_center", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
+    POINT_ROBINSON = HPhoneTup("point_robinson", "audio-orcasound-net", "rpi_point_robinson", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
+    NORTH_SJC = HPhoneTup("north_sjc", "audio-orcasound-net", "rpi_north_sjc", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)
     SANDBOX = HPhoneTup("sandbox", "acoustic-sandbox", "ambient-sound-analysis", "acoustic-sandbox", "ambient-sound-analysis/data", "ambient-sound-analysis", 71.6406580028601)

--- a/tests/test_FileConnector.py
+++ b/tests/test_FileConnector.py
@@ -1,6 +1,25 @@
 import datetime as dt
+import pytest
+from unittest.mock import Mock, patch, MagicMock, call
+import sys
+import os
 
-from orcasound_noise.utils.file_connector import S3FileConnector
+# Add src directory to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../src'))
+
+# Mock boto3 and botocore before importing file_connector
+with patch.dict(sys.modules, {
+    'boto3': MagicMock(),
+    'botocore': MagicMock(),
+    'botocore.config': MagicMock(),
+    'botocore.exceptions': MagicMock(),
+}):
+    # Set up the Config class and UNSIGNED constant on the mocked modules
+    sys.modules['botocore.config'].Config = MagicMock()
+    sys.modules['botocore'].UNSIGNED = 'aws:unsigned'
+    sys.modules['botocore.exceptions'].ClientError = Exception
+    
+    from orcasound_noise.utils.file_connector import S3FileConnector
 
 def test_create_filename():
     filename = S3FileConnector.create_filename(
@@ -22,3 +41,129 @@ def test_parse_filename():
         100,
         "delta_hz"
     ]
+
+
+class TestUploadPartitionedFolder:
+    """Test suite for upload_partitioned_folder method"""
+    
+    @pytest.fixture
+    def mock_hydrophone(self):
+        """Create a mock hydrophone for testing"""
+        mock_hp = MagicMock()
+        mock_hp.value.bucket = 'test-source-bucket'
+        mock_hp.value.ref_folder = 'ref-folder'
+        mock_hp.value.save_bucket = 'test-archive-bucket'
+        mock_hp.value.save_folder = 'archive/psd'
+        return mock_hp
+    
+    @patch('orcasound_noise.utils.file_connector.boto3.resource')
+    @patch('orcasound_noise.utils.file_connector.boto3.client')
+    def test_upload_partitioned_folder_valid_path(self, mock_boto_client, mock_boto_resource, mock_hydrophone):
+        """Test successful upload with valid folder path containing save_folder"""
+        with patch('subprocess.run') as mock_subprocess:
+            connector = S3FileConnector(mock_hydrophone)
+            folder_path = '/local/path/archive/psd/year=2023/month=01'
+            
+            connector.upload_partitioned_folder(folder_path)
+            
+            # Verify subprocess.run was called with correct arguments
+            expected_cmd = [
+                'aws', 's3', 'sync',
+                folder_path,
+                's3://test-archive-bucket/archive/psd/',
+                '--no-overwrite'
+            ]
+            mock_subprocess.assert_called_once_with(expected_cmd, check=True)
+    
+    @patch('orcasound_noise.utils.file_connector.boto3.resource')
+    @patch('orcasound_noise.utils.file_connector.boto3.client')
+    def test_upload_partitioned_folder_validates_path(self, mock_boto_client, mock_boto_resource, mock_hydrophone):
+        """Test that ValueError is raised when folder_path doesn't contain save_folder"""
+        with patch('subprocess.run') as mock_subprocess:
+            connector = S3FileConnector(mock_hydrophone)
+            invalid_folder_path = '/local/path/wrong/folder/year=2023'
+            
+            with pytest.raises(ValueError, match="folder_path must include 'archive/psd'"):
+                connector.upload_partitioned_folder(invalid_folder_path)
+            
+            # subprocess.run should not be called
+            mock_subprocess.assert_not_called()
+    
+    @patch('orcasound_noise.utils.file_connector.boto3.resource')
+    @patch('orcasound_noise.utils.file_connector.boto3.client')
+    def test_upload_partitioned_folder_subprocess_failure(self, mock_boto_client, mock_boto_resource, mock_hydrophone):
+        """Test that subprocess failures are propagated"""
+        with patch('subprocess.run') as mock_subprocess:
+            mock_subprocess.side_effect = RuntimeError("AWS CLI not found")
+            
+            connector = S3FileConnector(mock_hydrophone)
+            folder_path = '/local/path/archive/psd/year=2023'
+            
+            with pytest.raises(RuntimeError, match="AWS CLI not found"):
+                connector.upload_partitioned_folder(folder_path)
+    
+    @patch('orcasound_noise.utils.file_connector.boto3.resource')
+    @patch('orcasound_noise.utils.file_connector.boto3.client')
+    def test_upload_partitioned_folder_with_multiple_levels(self, mock_boto_client, mock_boto_resource, mock_hydrophone):
+        """Test upload with deeply nested folder structure"""
+        with patch('subprocess.run') as mock_subprocess:
+            connector = S3FileConnector(mock_hydrophone)
+            folder_path = '/data/archive/psd/hydrophone=orca_lab/year=2026/month=02/day=05'
+            
+            connector.upload_partitioned_folder(folder_path)
+            
+            expected_cmd = [
+                'aws', 's3', 'sync',
+                folder_path,
+                's3://test-archive-bucket/archive/psd/',
+                '--no-overwrite'
+            ]
+            mock_subprocess.assert_called_once_with(expected_cmd, check=True)
+    
+    @patch('orcasound_noise.utils.file_connector.boto3.resource')
+    @patch('orcasound_noise.utils.file_connector.boto3.client')
+    def test_upload_partitioned_folder_case_sensitive(self, mock_boto_client, mock_boto_resource, mock_hydrophone):
+        """Test that save_folder matching is case sensitive"""
+        with patch('subprocess.run') as mock_subprocess:
+            connector = S3FileConnector(mock_hydrophone)
+            # Using uppercase version of save_folder should fail
+            invalid_folder_path = '/local/path/ARCHIVE/PSD/year=2023'
+            
+            with pytest.raises(ValueError, match="folder_path must include 'archive/psd'"):
+                connector.upload_partitioned_folder(invalid_folder_path)
+            
+            mock_subprocess.assert_not_called()
+    
+    @patch('orcasound_noise.utils.file_connector.boto3.resource')
+    @patch('orcasound_noise.utils.file_connector.boto3.client')
+    def test_upload_partitioned_folder_with_check_exception(self, mock_boto_client, mock_boto_resource, mock_hydrophone):
+        """Test that CalledProcessError is raised when subprocess check=True fails"""
+        import subprocess
+        
+        with patch('subprocess.run') as mock_subprocess:
+            mock_subprocess.side_effect = subprocess.CalledProcessError(1, 'aws s3 sync')
+            
+            connector = S3FileConnector(mock_hydrophone)
+            folder_path = '/local/path/archive/psd/year=2023'
+            
+            with pytest.raises(subprocess.CalledProcessError):
+                connector.upload_partitioned_folder(folder_path)
+    
+    @patch('orcasound_noise.utils.file_connector.boto3.resource')
+    @patch('orcasound_noise.utils.file_connector.boto3.client')
+    def test_upload_partitioned_folder_minimal_path(self, mock_boto_client, mock_boto_resource, mock_hydrophone):
+        """Test with minimal valid path (just save_folder)"""
+        with patch('subprocess.run') as mock_subprocess:
+            connector = S3FileConnector(mock_hydrophone)
+            # Minimal valid path
+            folder_path = 'archive/psd'
+            
+            connector.upload_partitioned_folder(folder_path)
+            
+            expected_cmd = [
+                'aws', 's3', 'sync',
+                folder_path,
+                's3://test-archive-bucket/archive/psd/',
+                '--no-overwrite'
+            ]
+            mock_subprocess.assert_called_once_with(expected_cmd, check=True)

--- a/tests/test_FileConnector.py
+++ b/tests/test_FileConnector.py
@@ -1,6 +1,6 @@
 import datetime as dt
 import pytest
-from unittest.mock import Mock, patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 import sys
 import os
 
@@ -73,7 +73,7 @@ class TestUploadPartitionedFolder:
                 's3://test-archive-bucket/archive/psd/',
                 '--no-overwrite'
             ]
-            mock_subprocess.assert_called_once_with(expected_cmd, check=True)
+            mock_subprocess.assert_called_once_with(expected_cmd, check=True, capture_output=True, text=True)
     
     @patch('orcasound_noise.utils.file_connector.boto3.resource')
     @patch('orcasound_noise.utils.file_connector.boto3.client')
@@ -118,7 +118,7 @@ class TestUploadPartitionedFolder:
                 's3://test-archive-bucket/archive/psd/',
                 '--no-overwrite'
             ]
-            mock_subprocess.assert_called_once_with(expected_cmd, check=True)
+            mock_subprocess.assert_called_once_with(expected_cmd, check=True, capture_output=True, text=True)
     
     @patch('orcasound_noise.utils.file_connector.boto3.resource')
     @patch('orcasound_noise.utils.file_connector.boto3.client')
@@ -166,4 +166,4 @@ class TestUploadPartitionedFolder:
                 's3://test-archive-bucket/archive/psd/',
                 '--no-overwrite'
             ]
-            mock_subprocess.assert_called_once_with(expected_cmd, check=True)
+            mock_subprocess.assert_called_once_with(expected_cmd, check=True, capture_output=True, text=True)


### PR DESCRIPTION
This pull request introduces support for partitioned parquet file storage and S3 uploads in the Orcasound noise pipeline, along with enhancements to hydrophone configuration and robust testing for the new upload functionality. The most significant changes are the addition of partitioned parquet saving and S3 sync, improvements to hydrophone metadata, and comprehensive unit tests for the S3 upload logic.

Partitioned parquet file saving and S3 upload:

* Added a `partitioning` option to the `generate_parquet_file` method in `pipeline.py`, enabling partitioned parquet file creation by hydrophone, year, month, and day, and supporting upload to S3 using the AWS CLI.
* Introduced the `upload_partitioned_folder` method in `file_connector.py` to upload partitioned parquet folders to S3 via the AWS CLI, with validation of folder paths and error handling.

Hydrophone configuration improvements:

* Extended the `Hydrophone` enum to include additional hydrophones and updated its metadata to support partitioned data storage and bookmarks, improving flexibility for new locations and storage structures.

Environment and initialization enhancements:

* Updated the S3 connector initialization to optionally load environment variables from a `.env` file for local development, improving configuration flexibility and clarity. 

Testing for partitioned upload functionality:

* Added a comprehensive test suite for the `upload_partitioned_folder` method, covering valid uploads, path validation, subprocess failures, nested folder structures, case sensitivity, and minimal valid paths.

These changes collectively improve the pipeline's scalability, robustness, and test coverage for handling large, partitioned datasets and their upload to S3.