### PR TITLE
Add ship metrics pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pytest
 pytest-asyncio
 polars==1.38.0
 pyarrow==23.0.0
+geopandas==1.1.2

--- a/src/orcasound_noise/analysis/metrics/README.md
+++ b/src/orcasound_noise/analysis/metrics/README.md
@@ -1,0 +1,70 @@
+# Ship Metrics
+
+In the ship_metrics.py, the ShipMetricsCalculator allows users to calculate ship related metrics, including speed, duration, isolation flags, acoustic metrics, and distances to hydrophones. The README will introduce the definition and usage of the metrics.
+
+## Metrics
+
+## Ship Passage & Acoustic Metrics Data Dictionary
+
+| Column Name  | Description | Availability |
+|--------------|------------|------------|
+| `id_track`  | unique id for vessel tracking ||
+| `s_timestamp` | Local timestamp of first detection along track ||
+| `l_timestamp` | Local timestamp of last detection along track ||
+| `duration` | Time spent in designated zone of interest (seconds) ||
+| `avg_speed` | Average speed ||
+| `max_speed` | Maximum speed ||
+| `min_speed` | Minimum speed ||
+| `distance` | Total distance target traveled along track (kilometers) ||
+| `curviness` | Total distance along track divided by distance between first and last detection ||
+| `confidence` | Target confidence score (0–1) reflecting likelihood that a target is a true vessel and not a false detection (if available at site) ||
+| `mmsi` | Ship ID (Maritime Mobile Service Identity) | Available if the vessel tracking is associated to an AIS tracking id  |
+| `name` | Name of the ship | Available if the vessel tracking is associated to an AIS tracking id  |
+| `draft` | Distance between water surface and lowest point on vessel reported in AIS data (meters) | Available if the vessel tracking is associated to an AIS tracking id  |
+| `type id` | Ship type id | Available if the vessel tracking is associated to an AIS tracking id  |
+| `type` | Ship type | Available if the vessel tracking is associated to an AIS tracking id  |
+| `is_isolated` | `True` if the `id_track` is the only tracked vessel between `s_timestamp` and `l_timestamp`, else `False` |
+| `bb_qXX` | The XXth percentile of the broadband between `s_timestamp` and `l_timestamp` |
+| `comm_bb_qXX` | The XXth percentile of the communication frequency (1000-6000 Hz) broadband between `s_timestamp` and `l_timestamp` |
+| `ship_bb_qXX` | The XXth percentile of the ship frequency  (10-200 Hz) broadband between `s_timestamp` and `l_timestamp` |
+| `bb_lsr_qXX` | The XXth percentile of the listening space reduction to the broadband between `s_datetime` and `l_datetime` |
+| `comm_bb_lsr_qXX` | The XXth percentile of the listening space reduction to the communication frequency (1000-6000 Hz) broadband between `s_datetime` and `l_datetime` |
+| `ship_bb_lsr_qXX` | The XXth percentile of the listening space reduction to the ship frequency (10-200 Hz) broadband between `s_datetime` and `l_datetime` |
+| `min_dist` | Minimum distance to the hydrophone location between `s_datetime` and `l_datetime`  |
+| `year` | The XXth percentile of the listening space reduction to the communication frequency broadband between `s_datetime` and `l_datetime` |
+| `month` | The XXth percentile of the listening space reduction to the ship frequency broadband between `s_datetime` and `l_datetime` |
+| `day` | Minimum distance to the hydrophone location between `s_datetime` and `l_datetime`  |
+
+# Example Usage
+
+load tracking data. One can skip this part if having M2 data in hand
+```{python}
+# User will need credential to access M2 data.
+from dotenv import load_dotenv
+load_dotenv()
+
+ship_pipeline = ShipAnalysisPipeline()
+lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2() # It will load the latest 7 days of tracking data.
+```
+
+Get the relevent time of the passages
+```{python}
+# `start` and `end` should be the earliest and latest date in the vessel tracking data
+start, end = ship_pipeline.start_date, ship_pipeline.end_date 
+```
+
+Load the relevent sound data. One can skip this part if having relevent sound data in hand
+```{python}
+start = dt.datetime.combine(start, dt.time.min) # earliest time in the date
+end = dt.datetime.combine(end, dt.time.max) # latest time in the date
+
+ac_orcalab = PartitionedAccessor(Hydrophone.ORCASOUND_LAB, start, end)
+lf_psd, lf_bb = ac_orcalab.get_dataframes(lazy=True)
+```
+
+Create a Calculator with radar tracking, ais tracking, and broadband data. All the input data should be `polars.LazyFrame`
+
+```{python}
+ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
+pl_ship_metrics = ship_metrics_cal.get_all_ship_metrics()
+```

--- a/src/orcasound_noise/analysis/metrics/README.md
+++ b/src/orcasound_noise/analysis/metrics/README.md
@@ -39,7 +39,7 @@ In the ship_metrics.py, the ShipMetricsCalculator allows users to calculate ship
 
 load tracking data. One can skip this part if having M2 data in hand
 ```{python}
-# User will need credential to access M2 data.
+# A user will need credentials to access M2 data.
 from dotenv import load_dotenv
 load_dotenv()
 

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -270,7 +270,6 @@ class ShipMetricsCalculator:
         target_crs: CRS to project geometries to for accurate distance calculation (default is UTM zone 10N for PNW, EPSG:32610)
         """
 
-        from shapely.geometry import Point
         from shapely import wkt
         
         # Hydrophone point (lon, lat)

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -1,5 +1,4 @@
 import datetime as dt
-from weakref import ref
 import geopandas as gpd
 import numpy as np
 import pandas as pd

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -334,74 +334,74 @@ class ShipMetricsCalculator:
 
 # Generate metrics and save to parquet
 
-if __name__ == "__main__":
-    from dotenv import load_dotenv
-    load_dotenv()
-    ship_pipeline = ShipAnalysisPipeline()
-    print("DataFrames loaded")
-    s_time = time.time()
+# if __name__ == "__main__":
+#     from dotenv import load_dotenv
+#     load_dotenv()
+#     ship_pipeline = ShipAnalysisPipeline()
+#     print("DataFrames loaded")
+#     s_time = time.time()
 
-    # For regular weekly data
-    lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2()
+#     # For regular weekly data
+#     lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2()
 
-    # For 7 days
-    # lf_ais = gpd.read_file('data/temp/2026-02-20_weekly/tracks_ais_7Day.shp')
-    # lf_radar = gpd.read_file('data/temp/2026-02-20_weekly/tracks_radar_7Day.shp')  
+#     # For 7 days
+#     # lf_ais = gpd.read_file('data/temp/2026-02-20_weekly/tracks_ais_7Day.shp')
+#     # lf_radar = gpd.read_file('data/temp/2026-02-20_weekly/tracks_radar_7Day.shp')  
 
-    # For testing with all data in Feb
-    # lf_ais = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_ais.shp')
-    # lf_radar = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_radar.shp') 
+#     # For testing with all data in Feb
+#     # lf_ais = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_ais.shp')
+#     # lf_radar = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_radar.shp') 
 
-    # local data need to convert geometry to WKT for Polars since Polars doesn't support geometry types 
-    # lf_ais["geometry"] = lf_ais.geometry.to_wkt()
-    # lf_radar["geometry"] = lf_radar.geometry.to_wkt()
-    # lf_ais = pl.from_pandas(lf_ais).lazy()
-    # lf_radar = pl.from_pandas(lf_radar).lazy()
+#     # local data need to convert geometry to WKT for Polars since Polars doesn't support geometry types 
+#     # lf_ais["geometry"] = lf_ais.geometry.to_wkt()
+#     # lf_radar["geometry"] = lf_radar.geometry.to_wkt()
+#     # lf_ais = pl.from_pandas(lf_ais).lazy()
+#     # lf_radar = pl.from_pandas(lf_radar).lazy()
     
-    e_time = time.time()
+#     e_time = time.time()
 
-    print(f"Raw data loaded from M2 in {e_time - s_time:.2f} seconds")
+#     print(f"Raw data loaded from M2 in {e_time - s_time:.2f} seconds")
     
-    print("Sound DataFrames loaded")
-    s_time = time.time()
+#     print("Sound DataFrames loaded")
+#     s_time = time.time()
     
-    # For regular weekly data
-    start, end = ship_pipeline.start_date, ship_pipeline.end_date
-    start = dt.datetime.combine(start, dt.time.min)
-    end = dt.datetime.combine(end, dt.time.max)
-    ac_orcalab = PartitionedAccessor(Hydrophone.ORCASOUND_LAB, start, end)
+#     # For regular weekly data
+#     start, end = ship_pipeline.start_date, ship_pipeline.end_date
+#     start = dt.datetime.combine(start, dt.time.min)
+#     end = dt.datetime.combine(end, dt.time.max)
+#     ac_orcalab = PartitionedAccessor(Hydrophone.ORCASOUND_LAB, start, end)
 
-    lf_psd, lf_bb = ac_orcalab.get_dataframes(lazy=True)
+#     lf_psd, lf_bb = ac_orcalab.get_dataframes(lazy=True)
 
-    # For testing with all data in Feb
-    # lf_bb = pl.read_parquet('data/sound/broadband/hydrophone=orcasound_lab/year=2026/month=02').lazy()
-    e_time = time.time()
-    print(f"DataFrames collected in {e_time - s_time:.2f} seconds")
+#     # For testing with all data in Feb
+#     # lf_bb = pl.read_parquet('data/sound/broadband/hydrophone=orcasound_lab/year=2026/month=02').lazy()
+#     e_time = time.time()
+#     print(f"DataFrames collected in {e_time - s_time:.2f} seconds")
 
-    # sample data for testing
-    lf_bb = lf_bb.with_columns(
-        bb = pl.col("0"),
-        comm_bb = pl.lit(1) * pl.col("0"),
-        ship_bb = pl.lit(1) * pl.col("0")
-    )
+#     # sample data for testing
+#     lf_bb = lf_bb.with_columns(
+#         bb = pl.col("0"),
+#         comm_bb = pl.lit(1) * pl.col("0"),
+#         ship_bb = pl.lit(1) * pl.col("0")
+#     )
 
-    print("calculate metrics")
-    s_time = time.time()
-    ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
-    pl_ship_metrics = ship_metrics_cal.get_all_ship_metrics()
-    e_time = time.time()
-    print(f"Ship metrics calculated in {e_time - s_time:.2f} seconds")
+#     print("calculate metrics")
+#     s_time = time.time()
+#     ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
+#     pl_ship_metrics = ship_metrics_cal.get_all_ship_metrics()
+#     e_time = time.time()
+#     print(f"Ship metrics calculated in {e_time - s_time:.2f} seconds")
 
-    pl_ship_metrics = pl_ship_metrics.with_columns([
-        pl.col("s_timestamp").dt.year().alias("year"),
-        pl.col("s_timestamp").dt.to_string("%m").alias("month"),
-        pl.col("s_timestamp").dt.to_string("%d").alias("day")
-    ])
+#     pl_ship_metrics = pl_ship_metrics.with_columns([
+#         pl.col("s_timestamp").dt.year().alias("year"),
+#         pl.col("s_timestamp").dt.to_string("%m").alias("month"),
+#         pl.col("s_timestamp").dt.to_string("%d").alias("day")
+#     ])
 
-    print(pl_ship_metrics.head())
-    # saving metrics to parquet with partitioning by year/month/day
-    pl_ship_metrics.write_parquet(
-        "data/temp_ship",
-        use_pyarrow=True,
-        pyarrow_options={"partition_cols": ["year", "month", "day"]}
-    )
+#     print(pl_ship_metrics.head())
+#     # saving metrics to parquet with partitioning by year/month/day
+#     pl_ship_metrics.write_parquet(
+#         "data/temp_ship",
+#         use_pyarrow=True,
+#         pyarrow_options={"partition_cols": ["year", "month", "day"]}
+#     )

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -1,0 +1,318 @@
+import datetime as dt
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import polars as pl
+from shapely.geometry import Point
+import time
+
+from orcasound_noise.analysis.partitioned_accessor import PartitionedAccessor
+from orcasound_noise.utils import Hydrophone
+from orcasound_noise.pipeline.pipeline import ShipAnalysisPipeline
+
+
+class ShipMetricsCalculator:
+    def __init__(self, lf_radar: pl.LazyFrame, lf_ais: pl.LazyFrame, lf_bb: pl.LazyFrame):
+        self.pl_radar = self.get_valid_radar_data(lf_radar)
+        self.pl_ais = self.clean_ais_data(lf_ais)
+        self.pl_sound = lf_bb 
+        self.hydrophone_metadata = {'coordinates': [-123.1735774, 48.5583362], # Orcasound_lab coordinates
+                                    'crs': {'properties': {'name': 'EPSG:4326'}, 
+                                            'type': 'name'}, 'type': 'Point'}
+        
+    
+    def clean_ais_data(self, lf_ais: pl.LazyFrame) -> pl.LazyFrame:
+        """
+        Processes raw AIS data to create a valid Polars DataFrame
+        with timestamps and cleaned MMSI/IMO fields.
+        """
+        return (
+            lf_ais
+            .with_columns([
+                # Clean id_track, MMSI and IMO fields (remove trailing .0 if present)
+                pl.col("id_track").cast(pl.Utf8).str.replace(r"\.0$", "").alias("id_track"),
+                pl.col("mmsi").cast(pl.Utf8).str.replace(r"\.0$", "").alias("mmsi"),
+                pl.col("imo").cast(pl.Utf8).str.replace(r"\.0$", "").alias("imo"),
+
+                # rename type to type_id
+                pl.col("type").alias("type_id")
+            ]).select(
+                ['id_track', 'mmsi', 'imo', 'name', 'draft', 'type_id']
+            )
+        )
+    
+    def get_valid_radar_data(self, lf_radar: pl.LazyFrame) -> pl.LazyFrame:
+        """
+        Processes raw radar data to create a valid Polars DataFrame
+        with timestamps and a validity flag based on confidence
+        and available association ID.
+        """
+        return (
+            lf_radar
+            .with_columns([
+                # Create timestamps
+                (pl.col("sdate") + " " + pl.col("stime"))
+                    .str.strptime(pl.Datetime, strict=False)
+                    .alias("s_timestamp"),
+
+                (pl.col("ldate") + " " + pl.col("ltime"))
+                    .str.strptime(pl.Datetime, strict=False)
+                    .alias("l_timestamp"),
+
+                (pl.col("assoc_id").cast(pl.Utf8).str.replace(r"\.0$", ""))
+                .alias("assoc_id"),
+
+                (pl.col("id_track").cast(pl.Utf8).str.replace(r"\.0$", ""))
+                .alias("id_track"),
+
+                # Validity flag
+                (
+                    (pl.col("confidence") >= 0.5) |
+                    (pl.col("assoc_id").is_not_null())
+                ).alias("valid")
+            ])
+            # Filter valid rows + non-null geometry
+            .filter(
+                (pl.col("valid")) &
+                (pl.col("geometry").is_not_null())
+            )
+            .sort("s_timestamp")
+        )
+
+    def ship_type_expr(self):
+        return (
+            pl.when(pl.col("type_id").is_null())
+            .then(None)
+            .when(pl.col("type_id") <= 0)
+            .then(pl.lit("-"))
+            .when(pl.col("type_id") <= 19)
+            .then(pl.lit("reserved"))
+            .when(pl.col("type_id") <= 29)
+            .then(pl.lit("wing_in_ground"))
+            .when(pl.col("type_id") <= 30)
+            .then(pl.lit("fishing"))
+            .when(pl.col("type_id") <= 32)
+            .then(pl.lit("towing"))
+            .when(pl.col("type_id") == 33)
+            .then(pl.lit("dredging_or_underwater_operations"))
+            .when(pl.col("type_id") == 34)
+            .then(pl.lit("diving_operations"))
+            .when(pl.col("type_id") == 35)
+            .then(pl.lit("military_operations"))
+            .when(pl.col("type_id") == 36)
+            .then(pl.lit("sailing"))
+            .when(pl.col("type_id") == 37)
+            .then(pl.lit("pleasure_craft"))
+            .when(pl.col("type_id") <= 39)
+            .then(pl.lit("reserved"))
+            .when(pl.col("type_id") <= 49)
+            .then(pl.lit("high_speed_craft"))
+            .when(pl.col("type_id") == 50)
+            .then(pl.lit("pilot_vessel"))
+            .when(pl.col("type_id") == 51)
+            .then(pl.lit("search_and_rescue_vessel"))
+            .when(pl.col("type_id") == 52)
+            .then(pl.lit("tug"))
+            .when(pl.col("type_id") == 53)
+            .then(pl.lit("port_tender"))
+            .when(pl.col("type_id") == 54)
+            .then(pl.lit("anti_pollution_equipment"))
+            .when(pl.col("type_id") == 55)
+            .then(pl.lit("law_enforcement"))
+            .when(pl.col("type_id") <= 57)
+            .then(pl.lit("spare_local_vessel"))
+            .when(pl.col("type_id") == 58)
+            .then(pl.lit("medical_transport"))
+            .when(pl.col("type_id") == 59)
+            .then(pl.lit("noncombatant_ship"))
+            .when(pl.col("type_id") <= 69)
+            .then(pl.lit("passenger"))
+            .when(pl.col("type_id") <= 79)
+            .then(pl.lit("cargo"))
+            .when(pl.col("type_id") <= 89)
+            .then(pl.lit("tanker"))
+            .when(pl.col("type_id") <= 99)
+            .then(pl.lit("other_type"))
+            .otherwise(pl.lit("unknown"))
+        )
+            
+
+    def join_ais_metadata(self, lf_radar: pl.LazyFrame) -> pl.LazyFrame:
+        return (
+            lf_radar
+            .join(
+                self.pl_ais,
+                left_on="assoc_id",
+                right_on="id_track",
+                how="left"
+            )
+            .with_columns(
+                self.ship_type_expr().alias("type")
+            )
+        )
+        
+    def add_isolation_flag(self, lf_radar: pl.LazyFrame) -> pl.LazyFrame:
+        '''
+        Adds an 'is_isolated' boolean column to the radar LazyFrame indicating whether each track is isolated (no overlapping tracks) or not.
+        '''
+        # 1. Create a version of the data to check for 'others'
+        others = lf_radar.select(["id_track", "s_timestamp", "l_timestamp"])
+
+        # Use join(how="cross") instead of "left" with on=None
+        overlaps = (
+            lf_radar.join(others, how="cross", suffix="_other")
+            .filter(
+                (pl.col("s_timestamp") <= pl.col("l_timestamp_other")) &
+                (pl.col("l_timestamp") >= pl.col("s_timestamp_other")) &
+                (pl.col("id_track") != pl.col("id_track_other"))
+            )
+            .select("id_track")
+            .unique()
+            .with_columns(is_isolated=pl.lit(False))
+        )
+
+        return (
+            lf_radar.join(overlaps, on="id_track", how="left")
+            .with_columns(
+                pl.col("is_isolated").fill_null(True)
+            )
+        )
+
+    def add_acoustic_metrics(self, lf_radar: pl.LazyFrame, lf_sound: pl.LazyFrame) -> pl.LazyFrame:
+        """
+        Calculates all quantiles for all ships in one lazy operation.
+        """
+        
+        # 1. Join sound data to radar tracks based on the time window
+        # Note: Using 'join_where' is the modern, fast way to do range joins in Polars
+        # Replace "__index_level_0__" with your actual sound timestamp column name
+        combined = lf_radar.join_where(
+            lf_sound,
+            pl.col("s_timestamp") <= pl.col("__index_level_0__"),
+            pl.col("l_timestamp") >= pl.col("__index_level_0__")
+        )
+
+        # 2. Define the aggregations (these replace your get_quantiles logic)
+        # We do this for all three columns (comm_bb, bb, ship_bb) at once
+        quantile_exprs = []
+        for col, prefix in [("comm_bb", "comm_bb"), ("bb", "bb"), ("ship_bb", "ship_bb")]:
+            quantile_exprs.extend([
+                pl.col(col).mean().alias(f"{prefix}_avg"),
+                pl.col(col).quantile(0.05).alias(f"{prefix}_q05"),
+                pl.col(col).quantile(0.25).alias(f"{prefix}_q25"),
+                pl.col(col).quantile(0.50).alias(f"{prefix}_q50"),
+                pl.col(col).quantile(0.75).alias(f"{prefix}_q75"),
+                pl.col(col).quantile(0.95).alias(f"{prefix}_q95"),
+            ])
+
+        # 3. Group by the track ID to collapse the sound samples into metrics
+        acoustic_stats = (
+            combined
+            .group_by("id_track")
+            .agg(quantile_exprs)
+        )
+
+        # 4. Join back to the original tracks (to keep ships that had no sound data)
+        return lf_radar.join(acoustic_stats, on="id_track", how="left")
+  
+
+    def get_distance_to_hydrophone(self, df: pl.DataFrame, hydrophone_metadata,
+                               target_crs="EPSG:32610") -> pl.Series:
+        
+        """
+        Compute minimum distance between each LineString track
+        and the hydrophone point.
+        Returns distance in meters.
+        """
+        from shapely.geometry import Point
+        from shapely import wkt
+        
+        # Hydrophone point (lon, lat)
+        lon, lat = hydrophone_metadata["coordinates"]
+        hydro_pt = gpd.GeoSeries([Point(lon, lat)], crs="EPSG:4326")
+
+        # Convert Polars → pandas
+        pdf = df.to_pandas()
+
+        # If geometry stored as WKB
+        pdf["geometry"] = pdf["geometry"].apply(wkt.loads)
+
+        gdf = gpd.GeoDataFrame(pdf, geometry="geometry", crs="EPSG:4326")
+
+        # Project to metric CRS
+        gdf_proj = gdf.to_crs(target_crs)
+        hydro_proj = hydro_pt.to_crs(target_crs).iloc[0]
+
+        distances = gdf_proj.distance(hydro_proj)
+
+        return pl.Series("distance_m", distances.values)
+
+    def get_all_ship_metrics(self) -> pl.DataFrame:
+        # 1. Start with valid radar data
+        lf_output = self.pl_radar.select([
+            'id_track', 'assoc_id', 's_timestamp', 'l_timestamp', 'duration',
+            'avg_speed', 'max_speed', 'min_speed',
+            'distance', 'curviness', 'confidence', 'geometry'
+        ])
+
+        # 2. Get AIS Metadata via Join (Vectorized)
+        # Note: I updated get_ais_metadata logic to handle the join internally
+        lf_output = self.join_ais_metadata(lf_output)
+        
+        # 3. Calculate Isolation (Vectorized)
+        # We use a join-filter strategy instead of a row-wise loop
+        lf_output = self.add_isolation_flag(lf_output)
+        
+        # 4. Acoustic Metrics
+        lf_output = self.add_acoustic_metrics(lf_output, self.pl_sound)
+        
+        # 5. Distance to Hydrophone 
+        # Since this uses GeoPandas, we must collect, compute
+        df_collected = lf_output.collect()
+        dist_series = self.get_distance_to_hydrophone(df_collected, self.hydrophone_metadata)
+        df_collected = df_collected.with_columns(min_dist = dist_series)
+        df_collected = df_collected.drop("geometry")
+
+        return df_collected
+    
+    
+if __name__ == "__main__":
+
+    ship_pipeline = ShipAnalysisPipeline()
+    print("DataFrames loaded")
+    s_time = time.time()
+    lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2()
+    # lf_ais = gpd.read_file('data/temp/2026-02-20_weekly/tracks_ais_7Day.shp')
+    # lf_radar = gpd.read_file('data/temp/2026-02-20_weekly/tracks_radar_7Day.shp')    
+    # lf_ais["geometry"] = lf_ais.geometry.to_wkt()
+    # lf_radar["geometry"] = lf_radar.geometry.to_wkt()
+    # lf_ais = pl.from_pandas(lf_ais).lazy()
+    # lf_radar = pl.from_pandas(lf_radar).lazy()
+    e_time = time.time()
+    print(f"Raw data loaded from M2 in {e_time - s_time:.2f} seconds")
+    start, end = ship_pipeline.s_date, ship_pipeline.e_date
+    start = dt.datetime.combine(start, dt.time.min)
+    end = dt.datetime.combine(end, dt.time.max)
+    ac_orcalab = PartitionedAccessor(Hydrophone.ORCASOUND_LAB, start, end)
+    
+    print("Sound DataFrames loaded")
+    s_time = time.time()
+    lf_psd, lf_bb = ac_orcalab.get_dataframes(lazy=True)
+    e_time = time.time()
+    print(f"DataFrames collected in {e_time - s_time:.2f} seconds")
+
+    # sample data for testing
+    lf_bb = lf_bb.with_columns(
+        bb = pl.col("0"),
+        comm_bb = pl.lit(1) * pl.col("0"),
+        ship_bb = pl.lit(1) * pl.col("0")
+    )
+
+    print("calculate metrics")
+    s_time = time.time()
+    ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
+    pl_radar = ship_metrics_cal.get_all_ship_metrics()
+    e_time = time.time()
+    print(f"Ship metrics calculated in {e_time - s_time:.2f} seconds")
+    print(pl_radar.head())
+   

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from weakref import ref
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -13,11 +14,18 @@ from orcasound_noise.pipeline.pipeline import ShipAnalysisPipeline
 
 class ShipMetricsCalculator:
     def __init__(self, lf_radar: pl.LazyFrame, lf_ais: pl.LazyFrame, lf_bb: pl.LazyFrame):
-        self.pl_radar = self.get_valid_radar_data(lf_radar)
-        self.pl_ais = self.clean_ais_data(lf_ais)
-        self.pl_sound = lf_bb 
+        """
+        Initializes the ShipMetricsCalculator with raw radar, AIS, and sound data.
+
+        lf_radar: LazyFrame with raw radar track data from M2
+        lf_ais: LazyFrame with raw AIS data from M2
+        lf_bb: LazyFrame with broadband sound data
+        """
+        self.lf_radar = self.get_valid_radar_data(lf_radar)
+        self.lf_ais = self.clean_ais_data(lf_ais)
+        self.lf_sound = lf_bb 
         self.hydrophone_metadata = {'coordinates': [-123.1735774, 48.5583362], # Orcasound_lab coordinates
-                                    'crs': {'properties': {'name': 'EPSG:4326'}, 
+                                    'crs': {'properties': {'name': 'EPSG:4326'},  # CRS for lat/lon
                                             'type': 'name'}, 'type': 'Point'}
         
     
@@ -25,6 +33,8 @@ class ShipMetricsCalculator:
         """
         Processes raw AIS data to create a valid Polars DataFrame
         with timestamps and cleaned MMSI/IMO fields.
+        
+        lf_ais: LazyFrame with raw AIS data
         """
         return (
             lf_ais
@@ -32,12 +42,14 @@ class ShipMetricsCalculator:
                 # Clean id_track, MMSI and IMO fields (remove trailing .0 if present)
                 pl.col("id_track").cast(pl.Utf8).str.replace(r"\.0$", "").alias("id_track"),
                 pl.col("mmsi").cast(pl.Utf8).str.replace(r"\.0$", "").alias("mmsi"),
-                pl.col("imo").cast(pl.Utf8).str.replace(r"\.0$", "").alias("imo"),
+
+                # remove imo because all values are either 0. or null
+                # pl.col("imo").cast(pl.Utf8).str.replace(r"\.0$", "").alias("imo"),
 
                 # rename type to type_id
                 pl.col("type").alias("type_id")
             ]).select(
-                ['id_track', 'mmsi', 'imo', 'name', 'draft', 'type_id']
+                ['id_track', 'mmsi', 'name', 'draft', 'type_id']
             )
         )
     
@@ -46,6 +58,8 @@ class ShipMetricsCalculator:
         Processes raw radar data to create a valid Polars DataFrame
         with timestamps and a validity flag based on confidence
         and available association ID.
+
+        lr_radar: LazyFrame with raw radar data
         """
         return (
             lf_radar
@@ -80,6 +94,10 @@ class ShipMetricsCalculator:
         )
 
     def ship_type_expr(self):
+        ''' 
+        Maps AIS type_id to human-readable ship type categories based on AIS standards from M2.
+
+        '''
         return (
             pl.when(pl.col("type_id").is_null())
             .then(None)
@@ -138,24 +156,31 @@ class ShipMetricsCalculator:
             
 
     def join_ais_metadata(self, lf_radar: pl.LazyFrame) -> pl.LazyFrame:
+        '''
+        Joins AIS metadata to the radar LazyFrame based on the association ID.
+
+        lf_radar: LazyFrame with radar tracks, must contain 'assoc_id' column
+        '''
         return (
             lf_radar
             .join(
-                self.pl_ais,
+                self.lf_ais,
                 left_on="assoc_id",
                 right_on="id_track",
                 how="left"
             )
             .with_columns(
                 self.ship_type_expr().alias("type")
-            )
+            ).drop(['assoc_id'])
         )
         
     def add_isolation_flag(self, lf_radar: pl.LazyFrame) -> pl.LazyFrame:
         '''
         Adds an 'is_isolated' boolean column to the radar LazyFrame indicating whether each track is isolated (no overlapping tracks) or not.
+
+        lf_radar: LazyFrame with radar tracks
         '''
-        # 1. Create a version of the data to check for 'others'
+        # Create a version of the data to check for 'others'
         others = lf_radar.select(["id_track", "s_timestamp", "l_timestamp"])
 
         # Use join(how="cross") instead of "left" with on=None
@@ -178,34 +203,54 @@ class ShipMetricsCalculator:
             )
         )
 
-    def add_acoustic_metrics(self, lf_radar: pl.LazyFrame, lf_sound: pl.LazyFrame) -> pl.LazyFrame:
+    def add_acoustic_metrics(self, lf_radar: pl.LazyFrame, lf_sound: pl.LazyFrame, ref_comm_bb: float=0.0, ref_bb: float=0.0) -> pl.LazyFrame:
         """
         Calculates all quantiles for all ships in one lazy operation.
+
+        lr_radar: LazyFrame with radar tracks
+        lf_sound: LazyFrame with sound data
+        ref_comm: reference community background noise level for LSR calculation # 76.3
+        ref_bb: reference broadband noise level for LSR calculation # 76.6
         """
         
+        # Define a helper function to calculate LSR for a given column and reference level
+        def lsr(col_name, ref):
+            '''
+            Calculates the LSR for a given column and reference level using the formula:
+            LSR = 100 * (1 - 10^(-2 * (col - ref) / 15))
+            '''
+            return 100 * (1 - 10 ** (-2 * (pl.col(col_name) - ref) / 15))
+        
         # 1. Join sound data to radar tracks based on the time window
-        # Note: Using 'join_where' is the modern, fast way to do range joins in Polars
-        # Replace "__index_level_0__" with your actual sound timestamp column name
+        # Replace "__index_level_0__" with actual sound timestamp column name
         combined = lf_radar.join_where(
             lf_sound,
             pl.col("s_timestamp") <= pl.col("__index_level_0__"),
             pl.col("l_timestamp") >= pl.col("__index_level_0__")
         )
 
-        # 2. Define the aggregations (these replace your get_quantiles logic)
-        # We do this for all three columns (comm_bb, bb, ship_bb) at once
+       
+        # 2. Define the aggregations
         quantile_exprs = []
-        for col, prefix in [("comm_bb", "comm_bb"), ("bb", "bb"), ("ship_bb", "ship_bb")]:
+        for col in ["comm_bb", "bb", "ship_bb"]:
             quantile_exprs.extend([
-                pl.col(col).mean().alias(f"{prefix}_avg"),
-                pl.col(col).quantile(0.05).alias(f"{prefix}_q05"),
-                pl.col(col).quantile(0.25).alias(f"{prefix}_q25"),
-                pl.col(col).quantile(0.50).alias(f"{prefix}_q50"),
-                pl.col(col).quantile(0.75).alias(f"{prefix}_q75"),
-                pl.col(col).quantile(0.95).alias(f"{prefix}_q95"),
+                pl.col(col).mean().alias(f"{col}_avg"),
+                pl.col(col).quantile(0.05).alias(f"{col}_q05"),
+                pl.col(col).quantile(0.25).alias(f"{col}_q25"),
+                pl.col(col).quantile(0.50).alias(f"{col}_q50"),
+                pl.col(col).quantile(0.75).alias(f"{col}_q75"),
+                pl.col(col).quantile(0.95).alias(f"{col}_q95"),
             ])
+        
+        # 3. Calculate LSR for bb and comm_bb
+        quantile_exprs.extend([
+            lsr("bb", ref_bb).quantile(0.50).alias("bb_lsr_q50"),
+            lsr("bb", ref_bb).quantile(0.95).alias("bb_lsr_q95"),
+            lsr("comm_bb", ref_comm_bb).quantile(0.50).alias("comm_bb_lsr_q50"),
+            lsr("comm_bb", ref_comm_bb).quantile(0.95).alias("comm_bb_lsr_q95"),
+        ])
 
-        # 3. Group by the track ID to collapse the sound samples into metrics
+        # 4. Group by the track ID to collapse the sound samples into metrics
         acoustic_stats = (
             combined
             .group_by("id_track")
@@ -215,29 +260,33 @@ class ShipMetricsCalculator:
         # 4. Join back to the original tracks (to keep ships that had no sound data)
         return lf_radar.join(acoustic_stats, on="id_track", how="left")
   
-
     def get_distance_to_hydrophone(self, df: pl.DataFrame, hydrophone_metadata,
                                target_crs="EPSG:32610") -> pl.Series:
         
         """
         Compute minimum distance between each LineString track
+
         and the hydrophone point.
-        Returns distance in meters.
+        df: Polars DataFrame with a 'geometry' column containing WKT LineStrings
+        hydrophone_metadata: dict with 'coordinates' (lon, lat) and 'crs' (CRS info) for the hydrophone location
+        target_crs: CRS to project geometries to for accurate distance calculation (default is UTM zone 10N for PNW, EPSG:32610)
         """
+
         from shapely.geometry import Point
         from shapely import wkt
         
         # Hydrophone point (lon, lat)
         lon, lat = hydrophone_metadata["coordinates"]
-        hydro_pt = gpd.GeoSeries([Point(lon, lat)], crs="EPSG:4326")
+        crs = hydrophone_metadata["crs"]["properties"]["name"]
+        hydro_pt = gpd.GeoSeries([Point(lon, lat)], crs=crs)
 
-        # Convert Polars → pandas
+        # Convert Polars to pandas
         pdf = df.to_pandas()
 
-        # If geometry stored as WKB
+        # Restore geometry stored as WKB
         pdf["geometry"] = pdf["geometry"].apply(wkt.loads)
 
-        gdf = gpd.GeoDataFrame(pdf, geometry="geometry", crs="EPSG:4326")
+        gdf = gpd.GeoDataFrame(pdf, geometry="geometry", crs=crs)
 
         # Project to metric CRS
         gdf_proj = gdf.to_crs(target_crs)
@@ -248,26 +297,27 @@ class ShipMetricsCalculator:
         return pl.Series("distance_m", distances.values)
 
     def get_all_ship_metrics(self) -> pl.DataFrame:
+        '''
+        Main function to calculate all ship metrics by combining radar, AIS, and sound data.
+        '''
         # 1. Start with valid radar data
-        lf_output = self.pl_radar.select([
+        lf_output = self.lf_radar.select([
             'id_track', 'assoc_id', 's_timestamp', 'l_timestamp', 'duration',
             'avg_speed', 'max_speed', 'min_speed',
             'distance', 'curviness', 'confidence', 'geometry'
         ])
 
-        # 2. Get AIS Metadata via Join (Vectorized)
-        # Note: I updated get_ais_metadata logic to handle the join internally
+        # 2. Get AIS Metadata via Join
         lf_output = self.join_ais_metadata(lf_output)
         
-        # 3. Calculate Isolation (Vectorized)
-        # We use a join-filter strategy instead of a row-wise loop
+        # 3. Calculate Isolation
         lf_output = self.add_isolation_flag(lf_output)
         
         # 4. Acoustic Metrics
-        lf_output = self.add_acoustic_metrics(lf_output, self.pl_sound)
+        lf_output = self.add_acoustic_metrics(lf_output, self.lf_sound)
         
         # 5. Distance to Hydrophone 
-        # Since this uses GeoPandas, we must collect, compute
+        # using collect and compute due to geopandas
         df_collected = lf_output.collect()
         dist_series = self.get_distance_to_hydrophone(df_collected, self.hydrophone_metadata)
         df_collected = df_collected.with_columns(min_dist = dist_series)
@@ -275,44 +325,75 @@ class ShipMetricsCalculator:
 
         return df_collected
     
+
+# Generate metrics and save to parquet
+
+# if __name__ == "__main__":
+
+#     ship_pipeline = ShipAnalysisPipeline()
+#     print("DataFrames loaded")
+#     s_time = time.time()
+
+#     # For regular weekly data
+#     # lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2()
+
+#     # For 7 days
+#     # lf_ais = gpd.read_file('data/temp/2026-02-20_weekly/tracks_ais_7Day.shp')
+#     # lf_radar = gpd.read_file('data/temp/2026-02-20_weekly/tracks_radar_7Day.shp')  
+
+#     # For testing with all data in Feb
+#     lf_ais = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_ais.shp')
+#     lf_radar = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_radar.shp')  
+#     lf_ais["geometry"] = lf_ais.geometry.to_wkt()
+#     lf_radar["geometry"] = lf_radar.geometry.to_wkt()
+#     lf_ais = pl.from_pandas(lf_ais).lazy()
+#     lf_radar = pl.from_pandas(lf_radar).lazy()
+#     e_time = time.time()
+
+#     print(f"Raw data loaded from M2 in {e_time - s_time:.2f} seconds")
     
-if __name__ == "__main__":
-
-    ship_pipeline = ShipAnalysisPipeline()
-    print("DataFrames loaded")
-    s_time = time.time()
-    lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2()
-    # lf_ais = gpd.read_file('data/temp/2026-02-20_weekly/tracks_ais_7Day.shp')
-    # lf_radar = gpd.read_file('data/temp/2026-02-20_weekly/tracks_radar_7Day.shp')    
-    # lf_ais["geometry"] = lf_ais.geometry.to_wkt()
-    # lf_radar["geometry"] = lf_radar.geometry.to_wkt()
-    # lf_ais = pl.from_pandas(lf_ais).lazy()
-    # lf_radar = pl.from_pandas(lf_radar).lazy()
-    e_time = time.time()
-    print(f"Raw data loaded from M2 in {e_time - s_time:.2f} seconds")
-    start, end = ship_pipeline.s_date, ship_pipeline.e_date
-    start = dt.datetime.combine(start, dt.time.min)
-    end = dt.datetime.combine(end, dt.time.max)
-    ac_orcalab = PartitionedAccessor(Hydrophone.ORCASOUND_LAB, start, end)
+#     print("Sound DataFrames loaded")
+#     s_time = time.time()
     
-    print("Sound DataFrames loaded")
-    s_time = time.time()
-    lf_psd, lf_bb = ac_orcalab.get_dataframes(lazy=True)
-    e_time = time.time()
-    print(f"DataFrames collected in {e_time - s_time:.2f} seconds")
+#     # For regular weekly data
+#     # start, end = ship_pipeline.s_date, ship_pipeline.e_date
+#     # start = dt.datetime.combine(start, dt.time.min)
+#     # end = dt.datetime.combine(end, dt.time.max)
+#     # ac_orcalab = PartitionedAccessor(Hydrophone.ORCASOUND_LAB, start, end)
 
-    # sample data for testing
-    lf_bb = lf_bb.with_columns(
-        bb = pl.col("0"),
-        comm_bb = pl.lit(1) * pl.col("0"),
-        ship_bb = pl.lit(1) * pl.col("0")
-    )
+#     # lf_psd, lf_bb = ac_orcalab.get_dataframes(lazy=True)
 
-    print("calculate metrics")
-    s_time = time.time()
-    ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
-    pl_radar = ship_metrics_cal.get_all_ship_metrics()
-    e_time = time.time()
-    print(f"Ship metrics calculated in {e_time - s_time:.2f} seconds")
-    print(pl_radar.head())
+#     # For testing with all data in Feb
+#     lf_bb = pl.read_parquet('data/sound/broadband/hydrophone=orcasound_lab/year=2026/month=02').lazy()
+#     e_time = time.time()
+#     print(f"DataFrames collected in {e_time - s_time:.2f} seconds")
+
+#     # sample data for testing
+#     lf_bb = lf_bb.with_columns(
+#         bb = pl.col("0"),
+#         comm_bb = pl.lit(1) * pl.col("0"),
+#         ship_bb = pl.lit(1) * pl.col("0")
+#     )
+
+#     print("calculate metrics")
+#     s_time = time.time()
+#     ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
+#     pl_ship_metrics = ship_metrics_cal.get_all_ship_metrics()
+#     e_time = time.time()
+#     print(f"Ship metrics calculated in {e_time - s_time:.2f} seconds")
+#     # print(pl_ship_metrics.head())
+
+#     pl_ship_metrics = pl_ship_metrics.with_columns([
+#         pl.col("s_timestamp").dt.year().alias("year"),
+#         pl.col("s_timestamp").dt.to_string("%m").alias("month"),
+#         pl.col("s_timestamp").dt.to_string("%d").alias("day")
+#     ])
+
+#     # saving metrics to parquet with partitioning by year/month/day
+#     pl_ship_metrics.write_parquet(
+#         "data/temp_ship",
+#         use_pyarrow=True,
+#         pyarrow_options={"partition_cols": ["year", "month", "day"]}
+#     )  
+    
    

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -1,6 +1,5 @@
 import datetime as dt
 import geopandas as gpd
-import pandas as pd
 import polars as pl
 from shapely.geometry import Point
 import time

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -57,7 +57,7 @@ class ShipMetricsCalculator:
         with timestamps and a validity flag based on confidence
         and available association ID.
 
-        lr_radar: LazyFrame with raw radar data
+        lf_radar: LazyFrame with raw radar data
         """
         return (
             lf_radar

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -205,7 +205,7 @@ class ShipMetricsCalculator:
         """
         Calculates all quantiles for all ships in one lazy operation.
 
-        lr_radar: LazyFrame with radar tracks
+        lf_radar: LazyFrame with radar tracks
         lf_sound: LazyFrame with sound data
         ref_comm: reference community background noise level for LSR calculation # 76.3
         ref_bb: reference broadband noise level for LSR calculation # 76.6

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -1,6 +1,5 @@
 import datetime as dt
 import geopandas as gpd
-import numpy as np
 import pandas as pd
 import polars as pl
 from shapely.geometry import Point

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -1,13 +1,8 @@
-import datetime as dt
 import geopandas as gpd
 import polars as pl
 from shapely.geometry import Point
 from shapely import wkt
 import time
-
-from orcasound_noise.analysis.partitioned_accessor import PartitionedAccessor
-from orcasound_noise.utils import Hydrophone
-from orcasound_noise.pipeline.pipeline import ShipAnalysisPipeline
 
 
 class ShipMetricsCalculator:
@@ -240,7 +235,6 @@ class ShipMetricsCalculator:
         quantile_exprs = []
         for col in ["comm_bb", "bb", "ship_bb"]:
             quantile_exprs.extend([
-                pl.col(col).mean().alias(f"{col}_avg"),
                 pl.col(col).quantile(0.05).alias(f"{col}_q05"),
                 pl.col(col).quantile(0.25).alias(f"{col}_q25"),
                 pl.col(col).quantile(0.50).alias(f"{col}_q50"),
@@ -327,81 +321,13 @@ class ShipMetricsCalculator:
         df_collected = lf_output.collect()
         dist_series = self.get_distance_to_hydrophone(df_collected, self.hydrophone_metadata)
         df_collected = df_collected.with_columns(min_dist = dist_series)
+        
+        # 6. Generate year/month/day columns for partitioning and drop geometry column
+        df_collected = df_collected.with_columns([
+            pl.col("s_timestamp").dt.year().alias("year"),
+            pl.col("s_timestamp").dt.to_string("%m").alias("month"),
+            pl.col("s_timestamp").dt.to_string("%d").alias("day")
+        ])
         df_collected = df_collected.drop("geometry")
 
         return df_collected
-    
-
-# Generate metrics and save to parquet
-
-# if __name__ == "__main__":
-#     from dotenv import load_dotenv
-#     load_dotenv()
-#     ship_pipeline = ShipAnalysisPipeline()
-#     print("DataFrames loaded")
-#     s_time = time.time()
-
-#     # For regular weekly data
-#     lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2()
-
-#     # For 7 days
-#     # lf_ais = gpd.read_file('data/temp/2026-02-20_weekly/tracks_ais_7Day.shp')
-#     # lf_radar = gpd.read_file('data/temp/2026-02-20_weekly/tracks_radar_7Day.shp')  
-
-#     # For testing with all data in Feb
-#     # lf_ais = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_ais.shp')
-#     # lf_radar = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_radar.shp') 
-
-#     # local data need to convert geometry to WKT for Polars since Polars doesn't support geometry types 
-#     # lf_ais["geometry"] = lf_ais.geometry.to_wkt()
-#     # lf_radar["geometry"] = lf_radar.geometry.to_wkt()
-#     # lf_ais = pl.from_pandas(lf_ais).lazy()
-#     # lf_radar = pl.from_pandas(lf_radar).lazy()
-    
-#     e_time = time.time()
-
-#     print(f"Raw data loaded from M2 in {e_time - s_time:.2f} seconds")
-    
-#     print("Sound DataFrames loaded")
-#     s_time = time.time()
-    
-#     # For regular weekly data
-#     start, end = ship_pipeline.start_date, ship_pipeline.end_date
-#     start = dt.datetime.combine(start, dt.time.min)
-#     end = dt.datetime.combine(end, dt.time.max)
-#     ac_orcalab = PartitionedAccessor(Hydrophone.ORCASOUND_LAB, start, end)
-
-#     lf_psd, lf_bb = ac_orcalab.get_dataframes(lazy=True)
-
-#     # For testing with all data in Feb
-#     # lf_bb = pl.read_parquet('data/sound/broadband/hydrophone=orcasound_lab/year=2026/month=02').lazy()
-#     e_time = time.time()
-#     print(f"DataFrames collected in {e_time - s_time:.2f} seconds")
-
-#     # sample data for testing
-#     lf_bb = lf_bb.with_columns(
-#         bb = pl.col("0"),
-#         comm_bb = pl.lit(1) * pl.col("0"),
-#         ship_bb = pl.lit(1) * pl.col("0")
-#     )
-
-#     print("calculate metrics")
-#     s_time = time.time()
-#     ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
-#     pl_ship_metrics = ship_metrics_cal.get_all_ship_metrics()
-#     e_time = time.time()
-#     print(f"Ship metrics calculated in {e_time - s_time:.2f} seconds")
-
-#     pl_ship_metrics = pl_ship_metrics.with_columns([
-#         pl.col("s_timestamp").dt.year().alias("year"),
-#         pl.col("s_timestamp").dt.to_string("%m").alias("month"),
-#         pl.col("s_timestamp").dt.to_string("%d").alias("day")
-#     ])
-
-#     print(pl_ship_metrics.head())
-#     # saving metrics to parquet with partitioning by year/month/day
-#     pl_ship_metrics.write_parquet(
-#         "data/temp_ship",
-#         use_pyarrow=True,
-#         pyarrow_options={"partition_cols": ["year", "month", "day"]}
-#     )

--- a/src/orcasound_noise/analysis/metrics/ship_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/ship_metrics.py
@@ -2,6 +2,7 @@ import datetime as dt
 import geopandas as gpd
 import polars as pl
 from shapely.geometry import Point
+from shapely import wkt
 import time
 
 from orcasound_noise.analysis.partitioned_accessor import PartitionedAccessor
@@ -10,13 +11,13 @@ from orcasound_noise.pipeline.pipeline import ShipAnalysisPipeline
 
 
 class ShipMetricsCalculator:
-    def __init__(self, lf_radar: pl.LazyFrame, lf_ais: pl.LazyFrame, lf_bb: pl.LazyFrame):
+    def __init__(self, lf_radar: pl.LazyFrame, lf_ais: pl.LazyFrame, lf_bb: pl.LazyFrame) -> None:
         """
         Initializes the ShipMetricsCalculator with raw radar, AIS, and sound data.
-
-        lf_radar: LazyFrame with raw radar track data from M2
-        lf_ais: LazyFrame with raw AIS data from M2
-        lf_bb: LazyFrame with broadband sound data
+        Args:
+            lf_radar: LazyFrame with raw radar track data from M2
+            lf_ais: LazyFrame with raw AIS data from M2
+            lf_bb: LazyFrame with broadband sound data
         """
         self.lf_radar = self.get_valid_radar_data(lf_radar)
         self.lf_ais = self.clean_ais_data(lf_ais)
@@ -30,8 +31,10 @@ class ShipMetricsCalculator:
         """
         Processes raw AIS data to create a valid Polars DataFrame
         with timestamps and cleaned MMSI/IMO fields.
-        
-        lf_ais: LazyFrame with raw AIS data
+        Args:
+            lf_ais: LazyFrame with raw AIS data
+        Returns:
+            pl.LazyFrame: A cleaned LazyFrame with relevant AIS metadata.
         """
         return (
             lf_ais
@@ -55,8 +58,10 @@ class ShipMetricsCalculator:
         Processes raw radar data to create a valid Polars DataFrame
         with timestamps and a validity flag based on confidence
         and available association ID.
-
-        lf_radar: LazyFrame with raw radar data
+        Args:
+            lf_radar: LazyFrame with raw radar data
+        Returns:
+            pl.LazyFrame: A cleaned LazyFrame with valid radar tracks and timestamps.
         """
         return (
             lf_radar
@@ -152,21 +157,25 @@ class ShipMetricsCalculator:
         )
             
 
-    def join_ais_metadata(self, lf_radar: pl.LazyFrame) -> pl.LazyFrame:
+    def join_ais_metadata(self, lf_radar: pl.LazyFrame, lf_ais: pl.LazyFrame) -> pl.LazyFrame:
         '''
         Joins AIS metadata to the radar LazyFrame based on the association ID.
-
-        lf_radar: LazyFrame with radar tracks, must contain 'assoc_id' column
+        Args:
+            lf_radar: LazyFrame with radar tracks, must contain 'assoc_id' column
+            lf_ais: LazyFrame with AIS metadata
+        Returns:
+            pl.LazyFrame: A LazyFrame with AIS metadata joined to radar tracks, including a human-readable ship type column.
         '''
         return (
             lf_radar
             .join(
-                self.lf_ais,
+                lf_ais,
                 left_on="assoc_id",
                 right_on="id_track",
                 how="left"
             )
             .with_columns(
+                # Map AIS type_id to human-readable ship type categories
                 self.ship_type_expr().alias("type")
             ).drop(['assoc_id'])
         )
@@ -174,46 +183,47 @@ class ShipMetricsCalculator:
     def add_isolation_flag(self, lf_radar: pl.LazyFrame) -> pl.LazyFrame:
         '''
         Adds an 'is_isolated' boolean column to the radar LazyFrame indicating whether each track is isolated (no overlapping tracks) or not.
-
-        lf_radar: LazyFrame with radar tracks
+        Args:
+            lf_radar: LazyFrame with radar tracks
+        Returns:
+            pl.LazyFrame: A LazyFrame with an additional 'is_isolated' column indicating whether each track is isolated (no overlapping tracks) or not.
         '''
-        # Create a version of the data to check for 'others'
-        others = lf_radar.select(["id_track", "s_timestamp", "l_timestamp"])
-
-        # Use join(how="cross") instead of "left" with on=None
-        overlaps = (
-            lf_radar.join(others, how="cross", suffix="_other")
-            .filter(
-                (pl.col("s_timestamp") <= pl.col("l_timestamp_other")) &
-                (pl.col("l_timestamp") >= pl.col("s_timestamp_other")) &
-                (pl.col("id_track") != pl.col("id_track_other"))
-            )
-            .select("id_track")
-            .unique()
-            .with_columns(is_isolated=pl.lit(False))
-        )
 
         return (
-            lf_radar.join(overlaps, on="id_track", how="left")
+            lf_radar.sort("s_timestamp")
+            .with_columns([
+                # Get the latest end time seen so far (excluding current row)
+                pl.col("l_timestamp").cum_max().shift(1).alias("prev_max_end"),
+                # Get the earliest start time coming up (excluding current row)
+                pl.col("s_timestamp").shift(-1).alias("next_min_start")
+            ])
             .with_columns(
-                pl.col("is_isolated").fill_null(True)
+                is_isolated = (
+                    # No one before me overlaps
+                    (pl.col("prev_max_end").is_null() | (pl.col("s_timestamp") > pl.col("prev_max_end"))) &
+                    # No one after me overlaps
+                    (pl.col("next_min_start").is_null() | (pl.col("l_timestamp") < pl.col("next_min_start")))
+                )
             )
+            .drop(["prev_max_end", "next_min_start"])
         )
 
     def add_acoustic_metrics(self, lf_radar: pl.LazyFrame, lf_sound: pl.LazyFrame, ref_comm_bb: float=0.0, ref_bb: float=0.0) -> pl.LazyFrame:
         """
         Calculates all quantiles for all ships in one lazy operation.
-
-        lf_radar: LazyFrame with radar tracks
-        lf_sound: LazyFrame with sound data
-        ref_comm: reference community background noise level for LSR calculation # 76.3
-        ref_bb: reference broadband noise level for LSR calculation # 76.6
+        Args:
+            lf_radar: LazyFrame with radar tracks
+            lf_sound: LazyFrame with sound data
+            ref_comm: reference community background noise level for LSR calculation # 76.3
+            ref_bb: reference broadband noise level for LSR calculation # 76.6
+        Returns:
+            pl.LazyFrame: A LazyFrame with acoustic metrics (quantiles for broadband noise levels and LSR) aggregated for each ship track.
         """
         
         # Define a helper function to calculate LSR for a given column and reference level
         def lsr(col_name, ref):
             '''
-            Calculates the LSR for a given column and reference level using the formula:
+            Calculates the Listening Space Reduction (LSR) for a given column and reference level using the formula:
             LSR = 100 * (1 - 10^(-2 * (col - ref) / 15))
             '''
             return 100 * (1 - 10 ** (-2 * (pl.col(col_name) - ref) / 15))
@@ -226,7 +236,6 @@ class ShipMetricsCalculator:
             pl.col("l_timestamp") >= pl.col("__index_level_0__")
         )
 
-       
         # 2. Define the aggregations
         quantile_exprs = []
         for col in ["comm_bb", "bb", "ship_bb"]:
@@ -254,22 +263,21 @@ class ShipMetricsCalculator:
             .agg(quantile_exprs)
         )
 
-        # 4. Join back to the original tracks (to keep ships that had no sound data)
+        # 5. Join back to the original tracks (to keep ships that had no sound data)
         return lf_radar.join(acoustic_stats, on="id_track", how="left")
   
     def get_distance_to_hydrophone(self, df: pl.DataFrame, hydrophone_metadata,
                                target_crs="EPSG:32610") -> pl.Series:
         
         """
-        Compute minimum distance between each LineString track
-
-        and the hydrophone point.
-        df: Polars DataFrame with a 'geometry' column containing WKT LineStrings
-        hydrophone_metadata: dict with 'coordinates' (lon, lat) and 'crs' (CRS info) for the hydrophone location
-        target_crs: CRS to project geometries to for accurate distance calculation (default is UTM zone 10N for PNW, EPSG:32610)
+        Compute minimum distance between each LineString track and the hydrophone point.
+        Args:
+            df: Polars DataFrame with a 'geometry' column containing WKT LineStrings
+            hydrophone_metadata: dict with 'coordinates' (lon, lat) and 'crs' (CRS info) for the hydrophone location
+            target_crs: CRS to project geometries to for accurate distance calculation (default is UTM zone 10N for PNW, EPSG:32610)
+        Returns:
+            pl.Series: A Polars Series containing the minimum distance in meters from each track to the hydrophone.
         """
-
-        from shapely import wkt
         
         # Hydrophone point (lon, lat)
         lon, lat = hydrophone_metadata["coordinates"]
@@ -295,6 +303,8 @@ class ShipMetricsCalculator:
     def get_all_ship_metrics(self) -> pl.DataFrame:
         '''
         Main function to calculate all ship metrics by combining radar, AIS, and sound data.
+        returns:
+            pl.DataFrame: A Polars DataFrame containing all calculated ship metrics
         '''
         # 1. Start with valid radar data
         lf_output = self.lf_radar.select([
@@ -304,7 +314,7 @@ class ShipMetricsCalculator:
         ])
 
         # 2. Get AIS Metadata via Join
-        lf_output = self.join_ais_metadata(lf_output)
+        lf_output = self.join_ais_metadata(lf_output, self.lf_ais)
         
         # 3. Calculate Isolation
         lf_output = self.add_isolation_flag(lf_output)
@@ -324,72 +334,74 @@ class ShipMetricsCalculator:
 
 # Generate metrics and save to parquet
 
-# if __name__ == "__main__":
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+    load_dotenv()
+    ship_pipeline = ShipAnalysisPipeline()
+    print("DataFrames loaded")
+    s_time = time.time()
 
-#     ship_pipeline = ShipAnalysisPipeline()
-#     print("DataFrames loaded")
-#     s_time = time.time()
+    # For regular weekly data
+    lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2()
 
-#     # For regular weekly data
-#     # lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2()
+    # For 7 days
+    # lf_ais = gpd.read_file('data/temp/2026-02-20_weekly/tracks_ais_7Day.shp')
+    # lf_radar = gpd.read_file('data/temp/2026-02-20_weekly/tracks_radar_7Day.shp')  
 
-#     # For 7 days
-#     # lf_ais = gpd.read_file('data/temp/2026-02-20_weekly/tracks_ais_7Day.shp')
-#     # lf_radar = gpd.read_file('data/temp/2026-02-20_weekly/tracks_radar_7Day.shp')  
+    # For testing with all data in Feb
+    # lf_ais = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_ais.shp')
+    # lf_radar = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_radar.shp') 
 
-#     # For testing with all data in Feb
-#     lf_ais = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_ais.shp')
-#     lf_radar = gpd.read_file('data/ship/M2/26_2026_02/26_2026_02_tracks_radar.shp')  
-#     lf_ais["geometry"] = lf_ais.geometry.to_wkt()
-#     lf_radar["geometry"] = lf_radar.geometry.to_wkt()
-#     lf_ais = pl.from_pandas(lf_ais).lazy()
-#     lf_radar = pl.from_pandas(lf_radar).lazy()
-#     e_time = time.time()
-
-#     print(f"Raw data loaded from M2 in {e_time - s_time:.2f} seconds")
+    # local data need to convert geometry to WKT for Polars since Polars doesn't support geometry types 
+    # lf_ais["geometry"] = lf_ais.geometry.to_wkt()
+    # lf_radar["geometry"] = lf_radar.geometry.to_wkt()
+    # lf_ais = pl.from_pandas(lf_ais).lazy()
+    # lf_radar = pl.from_pandas(lf_radar).lazy()
     
-#     print("Sound DataFrames loaded")
-#     s_time = time.time()
+    e_time = time.time()
+
+    print(f"Raw data loaded from M2 in {e_time - s_time:.2f} seconds")
     
-#     # For regular weekly data
-#     # start, end = ship_pipeline.s_date, ship_pipeline.e_date
-#     # start = dt.datetime.combine(start, dt.time.min)
-#     # end = dt.datetime.combine(end, dt.time.max)
-#     # ac_orcalab = PartitionedAccessor(Hydrophone.ORCASOUND_LAB, start, end)
-
-#     # lf_psd, lf_bb = ac_orcalab.get_dataframes(lazy=True)
-
-#     # For testing with all data in Feb
-#     lf_bb = pl.read_parquet('data/sound/broadband/hydrophone=orcasound_lab/year=2026/month=02').lazy()
-#     e_time = time.time()
-#     print(f"DataFrames collected in {e_time - s_time:.2f} seconds")
-
-#     # sample data for testing
-#     lf_bb = lf_bb.with_columns(
-#         bb = pl.col("0"),
-#         comm_bb = pl.lit(1) * pl.col("0"),
-#         ship_bb = pl.lit(1) * pl.col("0")
-#     )
-
-#     print("calculate metrics")
-#     s_time = time.time()
-#     ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
-#     pl_ship_metrics = ship_metrics_cal.get_all_ship_metrics()
-#     e_time = time.time()
-#     print(f"Ship metrics calculated in {e_time - s_time:.2f} seconds")
-#     # print(pl_ship_metrics.head())
-
-#     pl_ship_metrics = pl_ship_metrics.with_columns([
-#         pl.col("s_timestamp").dt.year().alias("year"),
-#         pl.col("s_timestamp").dt.to_string("%m").alias("month"),
-#         pl.col("s_timestamp").dt.to_string("%d").alias("day")
-#     ])
-
-#     # saving metrics to parquet with partitioning by year/month/day
-#     pl_ship_metrics.write_parquet(
-#         "data/temp_ship",
-#         use_pyarrow=True,
-#         pyarrow_options={"partition_cols": ["year", "month", "day"]}
-#     )  
+    print("Sound DataFrames loaded")
+    s_time = time.time()
     
-   
+    # For regular weekly data
+    start, end = ship_pipeline.start_date, ship_pipeline.end_date
+    start = dt.datetime.combine(start, dt.time.min)
+    end = dt.datetime.combine(end, dt.time.max)
+    ac_orcalab = PartitionedAccessor(Hydrophone.ORCASOUND_LAB, start, end)
+
+    lf_psd, lf_bb = ac_orcalab.get_dataframes(lazy=True)
+
+    # For testing with all data in Feb
+    # lf_bb = pl.read_parquet('data/sound/broadband/hydrophone=orcasound_lab/year=2026/month=02').lazy()
+    e_time = time.time()
+    print(f"DataFrames collected in {e_time - s_time:.2f} seconds")
+
+    # sample data for testing
+    lf_bb = lf_bb.with_columns(
+        bb = pl.col("0"),
+        comm_bb = pl.lit(1) * pl.col("0"),
+        ship_bb = pl.lit(1) * pl.col("0")
+    )
+
+    print("calculate metrics")
+    s_time = time.time()
+    ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
+    pl_ship_metrics = ship_metrics_cal.get_all_ship_metrics()
+    e_time = time.time()
+    print(f"Ship metrics calculated in {e_time - s_time:.2f} seconds")
+
+    pl_ship_metrics = pl_ship_metrics.with_columns([
+        pl.col("s_timestamp").dt.year().alias("year"),
+        pl.col("s_timestamp").dt.to_string("%m").alias("month"),
+        pl.col("s_timestamp").dt.to_string("%d").alias("day")
+    ])
+
+    print(pl_ship_metrics.head())
+    # saving metrics to parquet with partitioning by year/month/day
+    pl_ship_metrics.write_parquet(
+        "data/temp_ship",
+        use_pyarrow=True,
+        pyarrow_options={"partition_cols": ["year", "month", "day"]}
+    )

--- a/src/orcasound_noise/analysis/partitioned_accessor.py
+++ b/src/orcasound_noise/analysis/partitioned_accessor.py
@@ -27,13 +27,16 @@ class PartitionedAccessor:
         self.bb_df = (pl.scan_parquet(bb_paths,  storage_options={'aws_region': 'us-west-2'})
                         .filter(pl.col("__index_level_0__").is_between(start_time, end_time)).sort("__index_level_0__"))
     
-    def get_dataframes(self):
+    def get_dataframes(self, lazy: bool = False):
         """
         Retrieves the PSD and broadband noise levels DataFrames for the specified time range.
         Returns:
             tuple: A tuple containing the PSD DataFrame and the broadband noise levels DataFrame for the specified time range.
         """
-        return self.psd_df.collect(), self.bb_df.collect()
+        if lazy:
+            return self.psd_df, self.bb_df
+        else:
+            return self.psd_df.collect(), self.bb_df.collect()
     
     # Currently assuming that data settings are delta_f = 1 and bands = 12 for calculating broadband noise levels, but this may need to be updated if data settings change
     def get_broadband(self, freq_low: int, freq_high: int, ref: float, name: str=None):

--- a/src/orcasound_noise/pipeline/README.md
+++ b/src/orcasound_noise/pipeline/README.md
@@ -93,7 +93,7 @@ A Power Spectral Density describes the power present in the audio signal as a fu
 A fast Fourier transform (FFT) is an algorithm that computes the discrete Fourier transform (DFT) of a sequence, or its inverse (IDFT). Fourier analysis converts a signal from its original domain (often time or space) to a representation in the frequency domain and vice versa.
 
 ## Ship Data Pipeline
-In this repo, we use ship tracking data from[Marine Monitor (M2)](https://m2marinemonitor.com/). M2 provides two types of data: AIS tracking data (received by an AIS receiver, if installed at the site) and radar tracking data (processed by a marine radar sensor). Currently, M2 only tracks vessels in the area of the `orcasound_lab` hydrophone.
+In this repo, we use ship tracking data from [Marine Monitor (M2)](https://m2marinemonitor.com/). M2 provides two types of data: AIS tracking data (received by an AIS receiver, if installed at the site) and radar tracking data (processed by a marine radar sensor). Currently, M2 only tracks vessels in the area of the `orcasound_lab` hydrophone.
 
 According to information from M2, the radar range is a conservative estimate of a reliable range of up to 5 nautical miles from the system. Sea and weather conditions may impact radar target detection and tracking. The AIS detection range of up to 25 nautical miles is an estimate based on data received by M2. 
 

--- a/src/orcasound_noise/pipeline/README.md
+++ b/src/orcasound_noise/pipeline/README.md
@@ -1,9 +1,11 @@
 # Pipeline
 
 This pipeline overview is designed to give users an understanding of how the data goes from individual hydrophones to 
-power spectral densities in the form of parquet files.
+power spectral densities in the form of parquet files, as well as the pipeline for pulling ship tracking data from Marine Monitor (M2).
 
-## Hydrophone Data Storage
+## Hydrophone data, PSD and BroadBand
+
+### Hydrophone Data Storage
 
 Orcasound has four hydrophones located throughout the Puget Sound that continuously collect underwater acoustic data. 
 Every few minutes, these hydrophones upload audio files, in the form of 10-second .ts clips, to Orcasound Amazon S3 buckets. 
@@ -14,7 +16,7 @@ The goal of this pipeline is to accurately and efficiently convert these .ts fil
 based on the user's chosen frequency bands, averaging time, and date selection, into power spectral densities in the form 
 of parquet files. This allows anyone to access this vast amount of data for exploration and understanding.
 
-## Creating a Pipeline Object
+### Creating a Pipeline Object
 
 Below we see the code needed to create a pipeline object. We initialize the object with Port Townsend as the chosen hydrophone, 
 1Hz bands, 60-second averaging time, and safe mode. Note, we assume for this pipeline overview that everything is done in safe mode,
@@ -29,9 +31,9 @@ if __name__ == '__main__':
                                      delta_t=60, mode='safe')
 ```
 
-## Creating a PSD
+### Creating a PSD
 
-### Initialization
+#### Initialization
 
 Using the pipeline object we created, we call generate_parquet_file with a given start and end time. This function 
 returns paths for the stored PSD and broadband parquet files. Users can read these parquet files as Dataframes for further 
@@ -44,7 +46,7 @@ psd_path, broadband_path = pipeline.generate_parquet_file(dt.datetime(2023, 3, 2
                                                           upload_to_s3=False)
 ```
 
-### Downloading and Converting the .ts Files
+#### Downloading and Converting the .ts Files
 
 The generate_parquet_file function calls the generate_psds function, both located in [pipeline.py](pipeline.py). This function begins by creating a DateRangeHLSStream object,
 providing a link to the Amazon S3 buckets with our desired hydrophone and date interval. Assuming we are operating in safe 
@@ -55,7 +57,7 @@ These 10-minute downloads of .ts files are then converted into 10-minute .wav fi
 unless otherwise specified. All of this work is done by the get_next_clip function, a method of DateRangeHLSStream objects 
 implemented in the orca_hls_utils package.
 
-### Conversion from .wav to PSD and Broadband
+#### Conversion from .wav to PSD and Broadband
 
 The 10-minute .wav files are created sequentially in a while loop. After the creation of each individual .wav file, we convert 
 that 10-minute .wav file into two Dataframes; one is a power spectral density and the other is broadband. This work is done 
@@ -69,7 +71,7 @@ run the pipeline for an hour of data from 11:00-12:00, we first download the .ts
 .wav format, calculate the PSD and broadband Dataframes, and store them in two separate lists with the generate_psds function. 
 We repeat this process 6 times in total, leaving us with a list of 6 10-minute PSD Dataframes and the same for broadband.
 
-### Generating the Parquet File
+#### Generating the Parquet File
 
 Still within the generate_psds function, we concatenate the PSD Dataframes and the broadband Dataframes, leaving us with 
 two Dataframes in total, one for PSD and one for broadband. Note, we then subtract the hydrophone's reference level from 
@@ -80,12 +82,30 @@ generate_ref function found in [pipeline.py](pipeline.py).
 Finally, generate_psds returns the complete PSD and broadband Dataframes to the generate_parquet_file function, which saves
 the two Dataframes and returns their file paths. We can then use these file paths to read the Dataframes for exploration.
 
-## Definitions
+### Definitions
 
-### PSD
+#### PSD
 
 A Power Spectral Density describes the power present in the audio signal as a function of frequency, per unit frequency and for a given averaging time. In this codebase, PSD values are generally stored as Pandas Dataframes, where the index represents the timestamps, the columns represent frequency bands, and each cell value represents the relative power in that frequency band and time interval, in decibels.
 
-### FFT
+#### FFT
 
 A fast Fourier transform (FFT) is an algorithm that computes the discrete Fourier transform (DFT) of a sequence, or its inverse (IDFT). Fourier analysis converts a signal from its original domain (often time or space) to a representation in the frequency domain and vice versa.
+
+## Ship Data Pipeline
+In this repo, we use ship tracking data from[Marine Monitor (M2)](https://m2marinemonitor.com/). M2 provides two types of data: AIS tracking data (received by an AIS receiver, if installed at the site) and radar tracking data (processed by a marine radar sensor). Currently, M2 only tracks vessels in the area of the `orcasound_lab` hydrophone.
+
+According to information from M2, the radar range is a conservative estimate of a reliable range of up to 5 nautical miles from the system. Sea and weather conditions may impact radar target detection and tracking. The AIS detection range of up to 25 nautical miles is an estimate based on data received by M2. 
+
+In our pipeline, we download a .zip file containing the latest weekly data from M2, unzip it, and transform it into a polars.LazyFrame for metric calculations.
+
+### Pipeline Usage 
+```{python}
+# A user will need credentials to access M2 data.
+from dotenv import load_dotenv
+load_dotenv()
+
+ship_pipeline = ShipAnalysisPipeline()
+lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2() # It will load the latest 7 days of tracking data.
+```
+```

--- a/src/orcasound_noise/pipeline/README.md
+++ b/src/orcasound_noise/pipeline/README.md
@@ -108,4 +108,3 @@ load_dotenv()
 ship_pipeline = ShipAnalysisPipeline()
 lf_ais, lf_radar = ship_pipeline.get_raw_data_from_m2() # It will load the latest 7 days of tracking data.
 ```
-```

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -13,6 +13,7 @@ import zipfile
 
 
 # Third part imports
+import geopandas as gpd
 import numpy as np
 import pandas as pd
 import polars as pl
@@ -465,52 +466,71 @@ class NoiseAnalysisPipeline:
         return ref
 
 class ShipAnalysisPipeline:
-    def __init__(self):
-        self.m2_token = dotenv.get_key('.env', 'M2_token')
-        self.user_id = dotenv.get_key('.env', 'user_id')
+    def __init__(self) -> None:
+        '''
+        Initialize the ShipAnalysisPipeline by setting up necessary parameters and temporary directories.
+        '''
+        self.m2_token = os.getenv("M2_token")
+        if not self.m2_token:
+            raise ValueError("M2_token is not set")
+        
+        # self.user_id = os.getenv("M2_user_id")
         self.radar_id = 26
         self._s_date, self._e_date = self._get_sdate_edate()
         self.url = f"https://m2mobile.protectedseas.net/api/map/{self.radar_id}/7day/download_weekly_zip"
+        self.folder_td = tempfile.TemporaryDirectory()
+        self.folder = self.folder_td.name
     
-    def _get_sdate_edate(self):
+    def _get_sdate_edate(self) -> tuple[dt.date, dt.date]:
+        '''
+        Get the start and end date for the M2 API request.
+        returns:
+            tuple[dt.date, dt.date]: Tuple of (start date, end date) where start date is 8 days ago and 
+        '''
         # get current time
         curr_date = dt.datetime.now(ZoneInfo("America/Los_Angeles")).date()
         s_date = curr_date - dt.timedelta(8)
         e_date = curr_date - dt.timedelta(1)
         return s_date, e_date
 
-    def get_raw_data_from_m2(self, temp_loc='./data/temp/', return_gdf=False):
+    def get_raw_data_from_m2(self, return_gdf=False) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | tuple[pl.LazyFrame, pl.LazyFrame]:
         """
-        Get raw AIS and radar data from M2 API for the past week, unzip the file, and return the geodataframes.
+        Get raw AIS and radar data from M2 API for the past week, unzip the file, and return the resulting track data.
+        Args:
+            return_gdf: If True, return the raw data as GeoDataFrames. If False
+        returns:
+            tuple[gpd.GeoDataFrame, gpd.GeoDataFrame] | tuple[pl.LazyFrame, pl.LazyFrame]: Tuple of (AIS data, Radar data) 
+            as either GeoDataFrames or Polars LazyFrames depending on the value of return_gdf.
         """
-        import geopandas as gpd
 
         headers = {   
             "Authorization": self.m2_token,
             "accept": "application/json"
         }
-        response = requests.get(self.url, headers=headers, timeout=300)
-        
-        if not os.path.exists(f"{temp_loc}"):
-            os.makedirs(f"{temp_loc}")
-                          
-        zip_path = Path(f"{temp_loc}{self.s_date}_weekly.zip")
-        output_dir = Path(f"{temp_loc}{self.s_date}_weekly")
+
+        # Make the GET request to download the zip file
+        try:
+            response = requests.get(self.url, headers=headers, timeout=300)
+        except requests.exceptions.RequestException as exc:
+            raise RuntimeError(f"Failed to download data from M2 API at {self.url}: {exc}") from exc
+       
+        zip_path = f"{self.folder}/{self.start_date}_weekly.zip"
+        output_dir = f"{self.folder}/{self.end_date}_weekly"
 
         # Save the zip file
         with open(zip_path, "wb") as f:
             f.write(response.content)
-        
+
         # Unzip
         with zipfile.ZipFile(zip_path, "r") as zip_ref:
             zip_ref.extractall(output_dir)
-    
+
         gdf_ais = gpd.read_file(f'{output_dir}/tracks_ais_7Day.shp')
         gdf_radar = gpd.read_file(f'{output_dir}/tracks_radar_7Day.shp')
 
         if return_gdf:
             return gdf_ais, gdf_radar
-        
+
         # Convert geometry to WKT (string)
         gdf_ais["geometry"] = gdf_ais.geometry.to_wkt()
         gdf_radar["geometry"] = gdf_radar.geometry.to_wkt()
@@ -519,13 +539,27 @@ class ShipAnalysisPipeline:
         pl_ais = pl.from_pandas(gdf_ais).lazy()
         pl_radar = pl.from_pandas(gdf_radar).lazy()
 
+        # cleanup temp files
+        self.cleanup()
+
         return pl_ais, pl_radar
 
+    def cleanup(self):
+        """
+        Cleanup any internally-created temporary directories.
+        """
+        # TemporaryDirectory.cleanup() is idempotent; guard for None/AttributeError.
+        try:
+            if self.folder_td is not None:
+                self.folder_td.cleanup()
+                self.folder_td = None
+        except AttributeError:
+            pass
+
     @property
-    def s_date(self):
+    def start_date(self):
         return self._s_date
-    
+
     @property
-    def e_date(self):
+    def end_date(self):
         return self._e_date
-    

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -5,16 +5,22 @@ import tempfile
 import time
 import logging
 import random
+import requests
+import dotenv
+from pathlib import Path
+from zoneinfo import ZoneInfo
+import zipfile
 
 
 # Third part imports
 import numpy as np
 import pandas as pd
+import polars as pl
 from multiprocessing import Pool
 
 # Local imports
 #
-# `orca_hls_utils` is an optional dependency when running purely local
+# `orca_hls_utils` is an optional dependency when runningg purely local
 # processing/tests. Import it lazily so importing this module does not fail
 # in environments that haven't installed the git dependency yet.
 try:
@@ -457,3 +463,69 @@ class NoiseAnalysisPipeline:
         ref = np.percentile(bb, 5)
 
         return ref
+
+class ShipAnalysisPipeline:
+    def __init__(self):
+        self.m2_token = dotenv.get_key('.env', 'M2_token')
+        self.user_id = dotenv.get_key('.env', 'user_id')
+        self.radar_id = 26
+        self._s_date, self._e_date = self.__get_sdate_edate()
+        self.url = f"https://m2mobile.protectedseas.net/api/map/{self.radar_id}/7day/download_weekly_zip"
+    
+    def __get_sdate_edate(self):
+        # get current time
+        curr_date = dt.datetime.now(ZoneInfo("America/Los_Angeles")).date()
+        s_date = curr_date - dt.timedelta(8)
+        e_date = curr_date - dt.timedelta(1)
+        return s_date, e_date
+
+    def get_raw_data_from_m2(self, temp_loc='./data/temp/', return_gdf=False):
+        """
+        Get raw AIS and radar data from M2 API for the past week, unzip the file, and return the geodataframes.
+        """
+        import geopandas as gpd
+
+        headers = {   
+            "Authorization": self.m2_token,
+            "accept": "application/json"
+        }
+        response = requests.get(self.url, headers=headers, timeout=300)
+        
+        if not os.path.exists(f"{temp_loc}"):
+            os.makedirs(f"{temp_loc}")
+                          
+        zip_path = Path(f"{temp_loc}{self.s_date}_weekly.zip")
+        output_dir = Path(f"{temp_loc}{self.s_date}_weekly")
+
+        # Save the zip file
+        with open(zip_path, "wb") as f:
+            f.write(response.content)
+        
+        # Unzip
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            zip_ref.extractall(output_dir)
+    
+        gdf_ais = gpd.read_file(f'{output_dir}/tracks_ais_7Day.shp')
+        gdf_radar = gpd.read_file(f'{output_dir}/tracks_radar_7Day.shp')
+
+        if return_gdf:
+            return gdf_ais, gdf_radar
+        
+        # Convert geometry to WKT (string)
+        gdf_ais["geometry"] = gdf_ais.geometry.to_wkt()
+        gdf_radar["geometry"] = gdf_radar.geometry.to_wkt()
+
+        # Convert to Polars
+        pl_ais = pl.from_pandas(gdf_ais).lazy()
+        pl_radar = pl.from_pandas(gdf_radar).lazy()
+
+        return pl_ais, pl_radar
+
+    @property
+    def s_date(self):
+        return self._s_date
+    
+    @property
+    def e_date(self):
+        return self._e_date
+    

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -20,7 +20,7 @@ from multiprocessing import Pool
 
 # Local imports
 #
-# `orca_hls_utils` is an optional dependency when runningg purely local
+# `orca_hls_utils` is an optional dependency when running purely local
 # processing/tests. Import it lazily so importing this module does not fail
 # in environments that haven't installed the git dependency yet.
 try:

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -475,7 +475,7 @@ class ShipAnalysisPipeline:
             raise ValueError("M2_token is not set")
         
         # self.user_id = os.getenv("M2_user_id")
-        self.radar_id = 26
+        self.radar_id = 26 # currently hardcoded to orcasound lab radar, can be made dynamic in the future
         self._s_date, self._e_date = self._get_sdate_edate()
         self.url = f"https://m2mobile.protectedseas.net/api/map/{self.radar_id}/7day/download_weekly_zip"
         self.folder_td = tempfile.TemporaryDirectory()

--- a/src/orcasound_noise/pipeline/pipeline.py
+++ b/src/orcasound_noise/pipeline/pipeline.py
@@ -469,10 +469,10 @@ class ShipAnalysisPipeline:
         self.m2_token = dotenv.get_key('.env', 'M2_token')
         self.user_id = dotenv.get_key('.env', 'user_id')
         self.radar_id = 26
-        self._s_date, self._e_date = self.__get_sdate_edate()
+        self._s_date, self._e_date = self._get_sdate_edate()
         self.url = f"https://m2mobile.protectedseas.net/api/map/{self.radar_id}/7day/download_weekly_zip"
     
-    def __get_sdate_edate(self):
+    def _get_sdate_edate(self):
         # get current time
         curr_date = dt.datetime.now(ZoneInfo("America/Los_Angeles")).date()
         s_date = curr_date - dt.timedelta(8)


### PR DESCRIPTION

1. src/orcasound_noise/pipeline/pipeline.py : Adds ShipAnalysisPipeline class for downloading weekly AIS/radar data from M2 API.
2. src/orcasound_noise/pipeline/README.md: Update readme to include ShipAnalysisPipeline.
3. src/orcasound_noise/analysis/metrics/ship_metrics.py :  Implements ShipMetricsCalculator for generating ship metrics, including isolation flags, acoustic metrics, and distances to hydrophones.
4. src/orcasound_noise/analysis/metrics/README.md :  Readme file for the usage of ShipMetricsCalculator.
5. src/orcasound_noise/analysis/partitioned_accessor.py : Adds lazy parameter to get_dataframes() method.
6. requirements.txt : Adds geopandas

