### PR TITLE
Add broadband metrics module

### DIFF
--- a/src/orcasound_noise/analysis/metrics/README.md
+++ b/src/orcasound_noise/analysis/metrics/README.md
@@ -1,3 +1,10 @@
+# Metrics
+
+- [Ship Metrics](#ship-metrics) — per-passage vessel acoustic and tracking metrics
+- [Broadband Metrics](#broadband-metrics) — aggregated broadband statistics over time
+
+---
+
 # Ship Metrics
 
 In the ship_metrics.py, the ShipMetricsCalculator allows users to calculate ship related metrics, including speed, duration, isolation flags, acoustic metrics, and distances to hydrophones. The README will introduce the definition and usage of the metrics.
@@ -68,3 +75,21 @@ Create a Calculator with radar tracking, ais tracking, and broadband data. All t
 ship_metrics_cal = ShipMetricsCalculator(lf_radar, lf_ais, lf_bb)
 pl_ship_metrics = ship_metrics_cal.get_all_ship_metrics()
 ```
+
+---
+
+# Broadband Metrics
+
+The `bb_metrics.py` module provides aggregated broadband statistics from the Hive-partitioned parquet data on S3. This is the beginning of a module to support analysis of broadband acoustic data across hydrophones.
+
+`get_broadband_metrics()` loads per-hydrophone broadband data and aggregates it over configurable time intervals (`minute`, `hour`, or `day`). For each of the three bands (`bb`, `comm_bb`, `ship_bb`), it computes:
+
+| Metric | Description |
+|--------|-------------|
+| `{band}_q05` | 5th percentile |
+| `{band}_q25` | 25th percentile |
+| `{band}_q50` | 50th percentile (median) |
+| `{band}_q75` | 75th percentile |
+| `{band}_q95` | 95th percentile |
+| `{band}_min` | Minimum value |
+| `{band}_max` | Maximum value |

--- a/src/orcasound_noise/analysis/metrics/bb_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/bb_metrics.py
@@ -27,7 +27,7 @@ def get_broadband_metrics(
     `point_robinson`, `north_sjc`, `sandbox`.
 
     Returned metrics for each of `bb`, `comm_bb`, and `ship_bb`:
-    `median`, `q05`, `q25`, `q75`, `q95`, `min`, `max`.
+    `q50`, `q05`, `q25`, `q75`, `q95`, `min`, `max`.
     """
     hydrophones = [hydrophones] if isinstance(hydrophones, Hydrophone) else list(hydrophones)
     if not hydrophones:
@@ -50,10 +50,10 @@ def get_broadband_metrics(
             }
         )
 
-    broadband_df = pl.concat(frames, how="diagonal_relaxed").sort(["hydrophone", "ind"])
+    broadband_lf = pl.concat(frames, how="vertical").sort(["hydrophone", "ind"])
 
     return (
-        broadband_df.lazy()
+        broadband_lf
         .with_columns(pl.col("ind").dt.truncate(INTERVALS[interval]).alias("bucket_start"))
         .group_by(["hydrophone", "bucket_start"])
         .agg(
@@ -61,7 +61,7 @@ def get_broadband_metrics(
                 expr
                 for band in BANDS
                 for expr in [
-                    pl.col(band).median().alias(f"{band}_median"),
+                    pl.col(band).quantile(0.50).alias(f"{band}_q50"),
                     pl.col(band).quantile(0.05).alias(f"{band}_q05"),
                     pl.col(band).quantile(0.25).alias(f"{band}_q25"),
                     pl.col(band).quantile(0.75).alias(f"{band}_q75"),
@@ -80,16 +80,13 @@ def _load_one_hydrophone(
     start: dt.datetime,
     end: dt.datetime,
     hydrophone: Hydrophone,
-) -> pl.DataFrame | None:
+) -> pl.LazyFrame | None:
     try:
         accessor = PartitionedAccessor(hydrophone, start_time=start, end_time=end)
-        df = accessor.bb_df.select(["ind", *BANDS]).collect()
+        lf = accessor.bb_df.select(["ind", *BANDS])
     except Exception:
         return None
 
-    if df.is_empty():
-        return None
-
-    return df.with_columns(
+    return lf.with_columns(
         pl.lit(hydrophone.value.name).alias("hydrophone"),
     )

--- a/src/orcasound_noise/analysis/metrics/bb_metrics.py
+++ b/src/orcasound_noise/analysis/metrics/bb_metrics.py
@@ -1,0 +1,95 @@
+import datetime as dt
+from collections.abc import Sequence
+from typing import Literal
+
+import polars as pl
+
+from ...utils import Hydrophone
+from ..partitioned_accessor import PartitionedAccessor
+
+BANDS = ("bb", "comm_bb", "ship_bb")
+INTERVALS = {"minute": "1m", "hour": "1h", "day": "1d"}
+Interval = Literal["minute", "hour", "day"]
+
+
+def get_broadband_metrics(
+    start: dt.datetime,
+    end: dt.datetime,
+    hydrophones: Hydrophone | Sequence[Hydrophone],
+    interval: Interval = "hour",
+) -> pl.DataFrame:
+    """
+    Load broadband data from S3 (Hive-partitioned parquet) and aggregate
+    it by `minute`, `hour`, or `day`.
+
+    Valid hydrophone names: `bush_point`, `orcasound_lab`,
+    `port_townsend`, `sunset_bay`, `andrews_bay`, `mast_center`,
+    `point_robinson`, `north_sjc`, `sandbox`.
+
+    Returned metrics for each of `bb`, `comm_bb`, and `ship_bb`:
+    `median`, `q05`, `q25`, `q75`, `q95`, `min`, `max`.
+    """
+    hydrophones = [hydrophones] if isinstance(hydrophones, Hydrophone) else list(hydrophones)
+    if not hydrophones:
+        raise ValueError("At least one hydrophone must be provided.")
+    if interval not in INTERVALS:
+        raise ValueError(
+            f"Unsupported interval '{interval}'. Choose from {sorted(INTERVALS)}."
+        )
+
+    frames = [
+        frame
+        for hydrophone in hydrophones
+        if (frame := _load_one_hydrophone(start, end, hydrophone)) is not None
+    ]
+    if not frames:
+        return pl.DataFrame(
+            schema={
+                "hydrophone": pl.Utf8,
+                "bucket_start": pl.Datetime,
+            }
+        )
+
+    broadband_df = pl.concat(frames, how="diagonal_relaxed").sort(["hydrophone", "ind"])
+
+    return (
+        broadband_df.lazy()
+        .with_columns(pl.col("ind").dt.truncate(INTERVALS[interval]).alias("bucket_start"))
+        .group_by(["hydrophone", "bucket_start"])
+        .agg(
+            [
+                expr
+                for band in BANDS
+                for expr in [
+                    pl.col(band).median().alias(f"{band}_median"),
+                    pl.col(band).quantile(0.05).alias(f"{band}_q05"),
+                    pl.col(band).quantile(0.25).alias(f"{band}_q25"),
+                    pl.col(band).quantile(0.75).alias(f"{band}_q75"),
+                    pl.col(band).quantile(0.95).alias(f"{band}_q95"),
+                    pl.col(band).min().alias(f"{band}_min"),
+                    pl.col(band).max().alias(f"{band}_max"),
+                ]
+            ]
+        )
+        .sort(["hydrophone", "bucket_start"])
+        .collect()
+    )
+
+
+def _load_one_hydrophone(
+    start: dt.datetime,
+    end: dt.datetime,
+    hydrophone: Hydrophone,
+) -> pl.DataFrame | None:
+    try:
+        accessor = PartitionedAccessor(hydrophone, start_time=start, end_time=end)
+        df = accessor.bb_df.select(["ind", *BANDS]).collect()
+    except Exception:
+        return None
+
+    if df.is_empty():
+        return None
+
+    return df.with_columns(
+        pl.lit(hydrophone.value.name).alias("hydrophone"),
+    )


### PR DESCRIPTION
## Summary

- Adds `bb_metrics.py`, a module for computing aggregated broadband metrics from Hive-partitioned parquet data on S3.
- Loads per-hydrophone broadband data via `PartitionedAccessor` and aggregates across configurable time intervals (minute, hour, day).
- Computes median, 5th/25th/75th/95th percentiles, min, and max for three bands: `bb`, `comm_bb`, and `ship_bb`.

## Test plan

- [x] Verify `get_broadband_metrics` returns expected schema for valid hydrophone/date ranges
